### PR TITLE
feat(desktop): build and publish the windows installer

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,95 @@
+# Construit l'installeur Windows et l'attache à la release du paquet `desktop`.
+#
+# Jusqu'ici rien ne produisait de binaire téléchargeable : `release.yml` ne fait
+# que du versionnage FerrFlow, et l'application n'existait donc nulle part sous
+# une forme installable. C'est ce que ce workflow ajoute.
+#
+# Volontairement séparé de `ci.yml` : la CI valide chaque commit et doit rester
+# rapide, alors qu'un bundle Tauri complet prend plusieurs minutes et n'a de sens
+# qu'une fois la version publiée.
+name: desktop build
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag de release à construire, par exemple desktop@v26.8.27"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  windows:
+    # FerrFlow publie une release par paquet du dépôt — `core@v…`, `vision@v…`,
+    # `desktop@v…`. Sans ce filtre, chaque release de crate déclencherait un
+    # bundle Tauri complet pour rien.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, 'desktop@v')
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Construire le tag publié, pas la tête de `main` : entre la release
+          # et l'exécution de ce job, `main` a pu avancer, et l'installeur
+          # porterait alors un numéro de version qui ne correspond à rien.
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: apps/desktop/pnpm-lock.yaml
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+
+      - name: Dépendances front
+        working-directory: apps/desktop
+        run: pnpm install --frozen-lockfile
+
+      # `tauri build` enchaîne le `beforeBuildCommand` (build Angular) puis le
+      # bundle. Pas de signature de mise à jour ici : la clé n'existe pas encore
+      # et l'auto-update viendra dans un second temps. L'installeur produit est
+      # complet et fonctionnel sans elle.
+      - name: Bundle Windows
+        working-directory: apps/desktop
+        run: pnpm tauri build
+
+      - name: Attacher l'installeur à la release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          bundles=(apps/desktop/src-tauri/target/release/bundle/nsis/*.exe)
+          if [ ${#bundles[@]} -eq 0 ]; then
+            echo "aucun installeur NSIS produit — le bundle a échoué en silence" >&2
+            exit 1
+          fi
+          printf 'installeur trouvé : %s\n' "${bundles[@]}"
+          gh release upload "$TAG" "${bundles[@]}" --clobber --repo "$GITHUB_REPOSITORY"
+
+      # Sur un déclenchement manuel il n'y a pas de release à alimenter, mais
+      # l'artefact reste récupérable : c'est ce qui permet de tester une
+      # construction sans publier quoi que ce soit.
+      - name: Conserver l'installeur comme artefact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: idlewarden-windows
+          path: apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error


### PR DESCRIPTION
Premier maillon pour qu'IdleWarden soit installable : jusqu'ici **aucun binaire téléchargeable n'existait nulle part**.

## L'état de départ

`release.yml` ne fait que du versionnage FerrFlow — il tague, il publie les crates, il ne construit pas l'application. Il n'y avait donc ni installeur, ni artefact, ni release portant quoi que ce soit d'exécutable.

Le reste de la chaîne est en revanche déjà en place et cohérent :

- `apps/desktop/src-tauri/src/updates.rs` sait déjà interroger l'endpoint de mise à jour, avec le canal et un identifiant d'installation pour le déploiement progressif ;
- l'API de `idlewarden-cloud` sert déjà le protocole, `rollout` et `yanked` compris ;
- son catalogue est simplement vide, d'où le 204 sur `/v1/update/…`.

Ce qui manquait était la construction.

## Ce que fait cette PR

Un workflow dédié qui, à la publication d'une release `desktop@v…`, construit le bundle Tauri sur `windows-latest` et attache l'installeur NSIS à cette release.

Le filtre sur `desktop@v` est nécessaire : FerrFlow publie une release **par paquet** du dépôt (`core@v…`, `vision@v…`, `bridge@v…`). Sans lui, chaque release de crate déclencherait un bundle Tauri complet pour rien.

Le job réutilise les conventions de `ci.yml` — pnpm, Node 22, `dtolnay/rust-toolchain`, `Swatinem/rust-cache` — et construit **le tag publié**, pas la tête de `main` : entre la release et l'exécution du job, `main` peut avoir avancé, et l'installeur porterait un numéro de version qui ne correspondrait à rien.

Le déclenchement manuel produit un artefact téléchargeable au lieu d'alimenter une release, ce qui permet d'essayer une construction sans rien publier.

## Ce que cette PR ne fait pas

**Pas d'auto-update.** Le bundle n'est pas signé et `createUpdaterArtifacts` reste désactivé, parce que la clé de signature n'existe pas encore — le commentaire en tête de `updates.rs` le dit déjà. L'installeur produit est complet et fonctionnel, il ne sait simplement pas se remplacer lui-même.

C'est délibérément séparé : la clé de signature d'un auto-updater est la racine de confiance qui autorise à remplacer un exécutable sur la machine des utilisateurs. Elle doit être générée par le propriétaire du projet, pas par un tiers, et elle bloquerait ce premier maillon sans raison.

La suite, dans l'ordre : générer la paire de clés, ajouter `tauri-plugin-updater` et la clé publique, activer les artefacts de mise à jour, puis publier le catalogue vers Garage pour que l'API le serve.

## Vérification

**Aucune, et il faut le dire.** Le crate `desktop` ne se construit pas sur la machine où cette PR a été écrite — `libdbus-sys` échoue faute de dépendances système — et il s'agit de toute façon d'un bundle Windows. La CI est la seule vérification possible.

À ne pas merger sans une exécution verte, et le déclenchement manuel est là exactement pour ça : lancer le workflow sur `desktop@v26.8.27` et vérifier que l'artefact sort, avant que le chemin automatique ne s'exécute pour de vrai.