### PR TITLE
fix(desktop): point pnpm setup at the app package.json

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -42,7 +42,14 @@ jobs:
           ref: ${{ inputs.tag || github.event.release.tag_name }}
           persist-credentials: false
 
+      # `package_json_file` est indispensable : la racine du dépôt est un
+      # workspace Cargo, sans `package.json`, et l'action y cherche la clé
+      # `packageManager` par défaut. Sans ce chemin elle échoue au démarrage
+      # avec « No pnpm version is specified ». `ci.yml` le passe déjà ; je
+      # l'avais omis en recopiant ses étapes.
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: apps/desktop/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: "22"


### PR DESCRIPTION
La première exécution du workflow de build échoue immédiatement :

```
Error: No pnpm version is specified.
Please specify it by one of the following ways:
  - in the GitHub Action config with the key "version"
  - in the package.json with the key "packageManager"
```

`pnpm/action-setup` cherche la clé `packageManager` dans le `package.json` **à la racine du dépôt**. Or la racine est un workspace Cargo et n'a pas de `package.json` : celui de l'application, qui porte bien `"packageManager": "pnpm@11.20.0"`, est dans `apps/desktop/`.

`ci.yml` passe déjà `package_json_file: apps/desktop/package.json` pour cette raison exacte. Je l'avais omis en recopiant ses étapes — l'erreur est la mienne, et elle n'était pas détectable avant la première exécution, GitHub ne pouvant pas lancer un workflow absent de la branche par défaut.

## Vérification

Le YAML est valide. Le reste ne peut être vérifié que par une nouvelle exécution : je relancerai le déclenchement manuel sur `desktop@v26.8.27` après le merge, ce qui produit un artefact sans rien publier.