### PR TITLE
feat(desktop): download and install updates through the plugin

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -66,13 +66,24 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # `tauri build` enchaîne le `beforeBuildCommand` (build Angular) puis le
-      # bundle. Pas de signature de mise à jour ici : la clé n'existe pas encore
-      # et l'auto-update viendra dans un second temps. L'installeur produit est
-      # complet et fonctionnel sans elle.
+      # bundle.
+      #
+      # Les deux variables de signature sont lues par le CLI Tauri sous ces noms
+      # exacts. `createUpdaterArtifacts` étant activé, leur absence n'est pas une
+      # dégradation silencieuse : le bundle échoue, ce qui est le bon
+      # comportement — une release sans signature ne serait acceptée par aucune
+      # installation existante.
       - name: Bundle Windows
         working-directory: apps/desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build
 
+      # `target/` est à la RACINE du dépôt, pas sous `apps/desktop/src-tauri/` :
+      # c'est un workspace Cargo, et tous les crates partagent le même
+      # répertoire de sortie. Tauri l'annonce d'ailleurs en fin de bundle
+      # (« Finished 2 bundles at: …/target/release/bundle/… »).
       - name: Attacher l'installeur à la release
         if: github.event_name == 'release'
         env:
@@ -82,13 +93,29 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          bundles=(apps/desktop/src-tauri/target/release/bundle/nsis/*.exe)
+          bundles=(target/release/bundle/nsis/*.exe)
           if [ ${#bundles[@]} -eq 0 ]; then
             echo "aucun installeur NSIS produit — le bundle a échoué en silence" >&2
             exit 1
           fi
-          printf 'installeur trouvé : %s\n' "${bundles[@]}"
-          gh release upload "$TAG" "${bundles[@]}" --clobber --repo "$GITHUB_REPOSITORY"
+
+          # L'archive de mise à jour et sa signature, produites par
+          # `createUpdaterArtifacts`. Leur absence est une erreur et non un
+          # avertissement : sans elles la release est installable à la main mais
+          # invisible pour l'auto-update, ce qui ne se remarque qu'au moment où
+          # personne ne reçoit la version suivante.
+          updaters=(target/release/bundle/nsis/*.nsis.zip)
+          sigs=(target/release/bundle/nsis/*.nsis.zip.sig)
+          if [ ${#updaters[@]} -eq 0 ] || [ ${#sigs[@]} -eq 0 ]; then
+            echo "artefact de mise à jour ou signature manquant" >&2
+            ls -R target/release/bundle >&2 || true
+            exit 1
+          fi
+
+          printf 'à publier : %s\n' "${bundles[@]}" "${updaters[@]}" "${sigs[@]}"
+          gh release upload "$TAG" \
+            "${bundles[@]}" "${updaters[@]}" "${sigs[@]}" \
+            --clobber --repo "$GITHUB_REPOSITORY"
 
       # Sur un déclenchement manuel il n'y a pas de release à alimenter, mais
       # l'artefact reste récupérable : c'est ce qui permet de tester une
@@ -98,5 +125,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: idlewarden-windows
-          path: apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
+          path: |
+            target/release/bundle/nsis/*.exe
+            target/release/bundle/nsis/*.nsis.zip
+            target/release/bundle/nsis/*.nsis.zip.sig
           if-no-files-found: error

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,5 +22,8 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tauri = { version = "2", features = [] }
-ureq = "3.2.1"
+# Télécharge, vérifie la signature minisign et remplace le binaire installé.
+# La vérification est le point important : sans elle, l'URL servie par
+# l'endpoint serait un vecteur d'exécution de code arbitraire.
+tauri-plugin-updater = "2"
 uuid = { version = "1.20.0", features = ["v4"] }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ pub fn run() {
     use tauri::Manager;
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
             app.manage(updates::Updates::new(app.handle()));
             Ok(())
@@ -25,7 +26,8 @@ pub fn run() {
             session::dispatch,
             updates::update_settings,
             updates::set_update_channel,
-            updates::check_for_update
+            updates::check_for_update,
+            updates::install_update
         ])
         .run(tauri::generate_context!())
         .expect("the tauri runtime failed to start");

--- a/apps/desktop/src-tauri/src/tests.rs
+++ b/apps/desktop/src-tauri/src/tests.rs
@@ -2,9 +2,7 @@
 
 use std::path::PathBuf;
 
-use crate::updates::{
-    check_url, install_id, load_settings, save_settings, Channel, CheckResult, Settings,
-};
+use crate::updates::{check_url, install_id, load_settings, save_settings, Channel, Settings};
 
 fn scratch(name: &str) -> PathBuf {
     let dir = std::env::temp_dir()

--- a/apps/desktop/src-tauri/src/tests.rs
+++ b/apps/desktop/src-tauri/src/tests.rs
@@ -3,8 +3,7 @@
 use std::path::PathBuf;
 
 use crate::updates::{
-    check_url, install_id, interpret, load_settings, save_settings, Channel, CheckResult, Settings,
-    UpdateError,
+    check_url, install_id, load_settings, save_settings, Channel, CheckResult, Settings,
 };
 
 fn scratch(name: &str) -> PathBuf {
@@ -39,50 +38,6 @@ fn a_trailing_slash_on_the_endpoint_does_not_double_up() {
         ),
         "https://idlewarden.com/api/v1/update/linux-x86_64/26.8.1?channel=beta"
     );
-}
-
-#[test]
-fn a_204_means_up_to_date_rather_than_a_failure() {
-    assert_eq!(interpret(204, "").unwrap(), CheckResult::UpToDate);
-}
-
-#[test]
-fn a_200_carries_the_offer() {
-    let body = r#"{"version":"26.9.0","pub_date":"2026-09-01T10:00:00Z",
-        "url":"https://example.test/a.zip","signature":"sig","notes":"Fixes things."}"#;
-
-    let CheckResult::Available { offer } = interpret(200, body).unwrap() else {
-        panic!("expected an offer");
-    };
-    assert_eq!(offer.version, "26.9.0");
-    assert_eq!(offer.notes.as_deref(), Some("Fixes things."));
-}
-
-#[test]
-fn an_offer_without_notes_is_still_an_offer() {
-    let body = r#"{"version":"26.9.0","pub_date":"x","url":"u","signature":"s"}"#;
-
-    let CheckResult::Available { offer } = interpret(200, body).unwrap() else {
-        panic!("expected an offer");
-    };
-    assert!(offer.notes.is_none());
-}
-
-#[test]
-fn a_garbled_offer_is_an_error_rather_than_a_silent_up_to_date() {
-    assert!(matches!(
-        interpret(200, "not json"),
-        Err(UpdateError::Malformed(_))
-    ));
-}
-
-#[test]
-fn any_other_status_is_reported_with_its_code() {
-    assert!(matches!(interpret(500, ""), Err(UpdateError::Status(500))));
-    assert!(matches!(
-        interpret(400, "{}"),
-        Err(UpdateError::Status(400))
-    ));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/updates.rs
+++ b/apps/desktop/src-tauri/src/updates.rs
@@ -66,12 +66,16 @@ pub enum CheckResult {
     Available { offer: Box<Offer> },
 }
 
+/// Les échecs que ce module peut rendre au front.
+///
+/// Plus de variante `Status` : c'est le plugin qui parle HTTP désormais, et il
+/// range les codes de réponse dans le message de ses propres erreurs, qui
+/// arrivent ici en `Unreachable`. Garder une variante que plus rien ne
+/// construit aurait laissé croire au front qu'il peut encore la distinguer.
 #[derive(Debug, thiserror::Error)]
 pub enum UpdateError {
     #[error("cannot reach the update endpoint: {0}")]
     Unreachable(String),
-    #[error("the update endpoint answered {0}")]
-    Status(u16),
     #[error("the update endpoint sent something unreadable: {0}")]
     Malformed(String),
     #[error("cannot read or write {path}: {source}")]

--- a/apps/desktop/src-tauri/src/updates.rs
+++ b/apps/desktop/src-tauri/src/updates.rs
@@ -1,14 +1,26 @@
 // SPDX-License-Identifier: MPL-2.0
 //! Asking the update endpoint whether a newer build exists.
 //!
-//! This crate only *asks*. Downloading, verifying a signature and replacing the
-//! binary belong to the updater plugin and to a signing key that does not exist
-//! yet, so nothing here touches the installed application.
+//! Ce module décide, le plugin exécute.
+//!
+//! L'interrogation passe par `tauri-plugin-updater` et non par un appel HTTP
+//! maison : l'endpoint sert déjà le format que le plugin attend — `version`,
+//! `pub_date`, `url`, `signature`, et un 204 pour « rien de neuf » — donc il
+//! n'y a rien à traduire entre les deux.
+//!
+//! Un seul chemin de requête, et c'est ce qui compte : le déploiement
+//! progressif est arbitré par l'endpoint à partir de l'en-tête d'installation.
+//! Deux chemins de vérification laisseraient une machine écartée du rollout
+//! recevoir la mise à jour par l'autre, sans que rien ne le signale.
+//!
+//! Ce qui reste ici est ce que le plugin ne sait pas faire : retenir le canal
+//! choisi, et donner à l'installation un identifiant stable.
 
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
+use tauri_plugin_updater::UpdaterExt;
 
 const ENDPOINT: &str = "https://idlewarden.com/api";
 const INSTALL_HEADER: &str = "x-idlewarden-install";
@@ -135,36 +147,6 @@ fn write(dir: &Path, path: &Path, body: &str) -> Result<(), UpdateError> {
     })
 }
 
-/// Turns the endpoint's answer into a result. 204 is the documented way of
-/// saying "you are already current", so it is not an error.
-pub fn interpret(status: u16, body: &str) -> Result<CheckResult, UpdateError> {
-    match status {
-        204 => Ok(CheckResult::UpToDate),
-        200 => serde_json::from_str::<Offer>(body)
-            .map(|offer| CheckResult::Available {
-                offer: Box::new(offer),
-            })
-            .map_err(|error| UpdateError::Malformed(error.to_string())),
-        other => Err(UpdateError::Status(other)),
-    }
-}
-
-fn ask(url: &str, install: &str) -> Result<CheckResult, UpdateError> {
-    let mut response = match ureq::get(url).header(INSTALL_HEADER, install).call() {
-        Ok(response) => response,
-        Err(ureq::Error::StatusCode(code)) => return Err(UpdateError::Status(code)),
-        Err(error) => return Err(UpdateError::Unreachable(error.to_string())),
-    };
-
-    let status = response.status().as_u16();
-    let body = response
-        .body_mut()
-        .read_to_string()
-        .map_err(|error| UpdateError::Malformed(error.to_string()))?;
-
-    interpret(status, &body)
-}
-
 pub struct Updates {
     pub directory: PathBuf,
 }
@@ -194,20 +176,100 @@ pub fn set_update_channel(
     Ok(settings)
 }
 
+/// Construit un updater visant le canal choisi, en annonçant l'installation.
+///
+/// L'endpoint est reconstruit à chaque appel plutôt que laissé à celui de
+/// `tauri.conf.json` : le canal est un paramètre de requête, et l'utilisateur
+/// peut en changer sans redémarrer l'application.
+async fn updater_for(
+    updates: &State<'_, Updates>,
+    app: &AppHandle,
+) -> Result<tauri_plugin_updater::Updater, UpdateError> {
+    let directory = updates.directory.clone();
+    let (settings, install) = tauri::async_runtime::spawn_blocking(move || {
+        let settings = load_settings(&directory);
+        install_id(&directory).map(|install| (settings, install))
+    })
+    .await
+    .map_err(|error| UpdateError::Unreachable(error.to_string()))??;
+
+    let current = app.package_info().version.to_string();
+    let url = check_url(ENDPOINT, target(), &current, settings.channel);
+    // Pas d'annotation de type : la cible est déduite de `endpoints`, ce qui
+    // évite de déclarer le crate `url` juste pour nommer une erreur.
+    let endpoint = url
+        .parse()
+        .map_err(|_| UpdateError::Malformed(format!("endpoint invalide : {url}")))?;
+
+    app.updater_builder()
+        .endpoints(vec![endpoint])
+        .map_err(|error| UpdateError::Unreachable(error.to_string()))?
+        .header(INSTALL_HEADER, install)
+        .map_err(|error| UpdateError::Unreachable(error.to_string()))?
+        .build()
+        .map_err(|error| UpdateError::Unreachable(error.to_string()))
+}
+
+fn offer_from(update: &tauri_plugin_updater::Update) -> Offer {
+    Offer {
+        version: update.version.clone(),
+        pub_date: update.date.map(|date| date.to_string()).unwrap_or_default(),
+        url: update.download_url.to_string(),
+        notes: update.body.clone(),
+    }
+}
+
 #[tauri::command]
 pub async fn check_for_update(
     updates: State<'_, Updates>,
     app: AppHandle,
 ) -> Result<CheckResult, UpdateError> {
-    let directory = updates.directory.clone();
-    let current = app.package_info().version.to_string();
+    let updater = updater_for(&updates, &app).await?;
+    match updater
+        .check()
+        .await
+        .map_err(|error| UpdateError::Unreachable(error.to_string()))?
+    {
+        None => Ok(CheckResult::UpToDate),
+        Some(update) => Ok(CheckResult::Available {
+            offer: Box::new(offer_from(&update)),
+        }),
+    }
+}
 
-    tauri::async_runtime::spawn_blocking(move || {
-        let settings = load_settings(&directory);
-        let install = install_id(&directory)?;
-        let url = check_url(ENDPOINT, target(), &current, settings.channel);
-        ask(&url, &install)
+/// Télécharge, vérifie la signature, et remplace l'installation.
+///
+/// La vérification est faite par le plugin contre la clé publique de
+/// `tauri.conf.json`. C'est elle qui empêche l'URL servie par l'endpoint d'être
+/// une exécution de code arbitraire : un binaire qui n'est pas signé par la clé
+/// privée correspondante est rejeté avant d'être écrit sur le disque.
+///
+/// La vérification est refaite ici au lieu de réutiliser l'offre précédente :
+/// le plugin ne rend pas d'objet transportable entre deux appels, et redemander
+/// garantit qu'on installe ce que l'endpoint propose maintenant — pas ce qu'il
+/// proposait quand l'utilisateur a cliqué, ce qui compte si la version vient
+/// d'être retirée.
+#[tauri::command]
+pub async fn install_update(
+    updates: State<'_, Updates>,
+    app: AppHandle,
+) -> Result<CheckResult, UpdateError> {
+    let updater = updater_for(&updates, &app).await?;
+    let Some(update) = updater
+        .check()
+        .await
+        .map_err(|error| UpdateError::Unreachable(error.to_string()))?
+    else {
+        return Ok(CheckResult::UpToDate);
+    };
+
+    let offer = offer_from(&update);
+    update
+        .download_and_install(|_downloaded, _total| {}, || {})
+        .await
+        .map_err(|error| UpdateError::Unreachable(error.to_string()))?;
+
+    Ok(CheckResult::Available {
+        offer: Box::new(offer),
     })
-    .await
-    .map_err(|error| UpdateError::Unreachable(error.to_string()))?
 }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -30,6 +30,15 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdDRjNBQkRDMTkzMUU3QkEKUldTNjV6RVozS3Z6ZkcyeGNvSm01L09zUVFIOVZUUXJrU0pYQUUxdmhjUXhUV1IyYWcyODRKRUIK",
+      "endpoints": [
+        "https://idlewarden.com/api/v1/update/{{target}}/{{current_version}}?channel=stable"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Complète la chaîne : l'application sait désormais se mettre à jour elle-même, et le workflow publie de quoi le lui permettre.

## Un seul chemin de vérification

`updates.rs` faisait sa propre requête HTTP avec `ureq`. Le plugin Tauri sait aussi interroger un endpoint. Les configurer tous les deux aurait créé deux voies de vérification — et le déploiement progressif n'étant arbitré que sur l'une, une machine écartée du rollout aurait pu recevoir la mise à jour par l'autre, sans que rien ne le signale.

La vérification passe donc entièrement par le plugin. C'est possible sans rien traduire parce que l'endpoint sert déjà le format qu'il attend : `version`, `pub_date`, `url`, `signature`, et un 204 pour « rien de neuf ». L'API avait été écrite pour lui.

`ask()`, `interpret()` et la dépendance `ureq` disparaissent. Ce qui reste dans le module est ce que le plugin ne sait pas faire : retenir le canal choisi, et donner à l'installation un identifiant stable pour que le rollout la classe toujours dans le même seau.

Le canal étant un paramètre de requête, l'endpoint est reconstruit à chaque appel plutôt que figé dans `tauri.conf.json` : passer de stable à beta prend effet sans redémarrage.

## La signature

`install_update` télécharge, fait vérifier la signature par le plugin contre la clé publique, puis remplace l'installation. C'est cette vérification qui empêche l'URL servie par l'endpoint d'être une exécution de code arbitraire.

La vérification est refaite au moment d'installer plutôt que de réutiliser l'offre affichée : on installe ce que l'endpoint propose maintenant, pas ce qu'il proposait quand l'utilisateur a cliqué — ce qui compte si la version vient d'être retirée entre les deux.

Côté CI, les deux secrets de signature sont passés au bundle, et l'archive de mise à jour et sa `.sig` sont publiées en plus de l'installeur. Leur absence fait **échouer** le job : une release sans signature s'installe à la main mais reste invisible pour l'auto-update, et ça ne se remarque qu'au moment où personne ne reçoit la version suivante.

## Correction d'un chemin, trouvée en exécutant

La construction de `desktop@v26.8.27` a produit l'installeur mais échoué à le récupérer :

```
Finished 2 bundles at:
    target\release\bundle\nsis\IdleWarden_26.8.27_x64-setup.exe
##[error]No files were found with the provided path: apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
```

`target/` est à la racine du dépôt, pas sous `apps/desktop/src-tauri/` : c'est un workspace Cargo, tous les crates partagent le même répertoire de sortie. Les sept chemins sont corrigés.

## Tests

Les cinq tests qui validaient le parsing des réponses HTTP sont retirés — ce code appartient désormais au plugin. Les dix autres, qui couvrent la construction d'URL, la persistance du canal et l'identifiant d'installation, sont intacts.

## Ce qui n'est pas vérifié

**Aucune ligne de ce Rust n'a été compilée.** La machine où cette PR a été écrite ne peut pas construire le crate — `libdbus-sys` échoue faute de dépendances système. `rustfmt` confirme la syntaxe, rien de plus.

Les appels au plugin — `updater_builder()`, `.endpoints()`, `.header()`, `update.date`, `download_and_install` — sont écrits d'après l'API de Tauri v2 sans vérification. `ci.yml` fait tourner `cargo clippy --workspace --all-targets` sur Linux et Windows : c'est lui qui tranchera, et il faut le lire avant de merger.

Restera ensuite le dernier maillon : publier le catalogue vers Garage pour que l'API cesse de répondre 204.