### PR TITLE
fix(desktop): attach the signature tauri v2 actually produces

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -99,22 +99,28 @@ jobs:
             exit 1
           fi
 
-          # L'archive de mise à jour et sa signature, produites par
-          # `createUpdaterArtifacts`. Leur absence est une erreur et non un
-          # avertissement : sans elles la release est installable à la main mais
-          # invisible pour l'auto-update, ce qui ne se remarque qu'au moment où
-          # personne ne reçoit la version suivante.
-          updaters=(target/release/bundle/nsis/*.nsis.zip)
-          sigs=(target/release/bundle/nsis/*.nsis.zip.sig)
-          if [ ${#updaters[@]} -eq 0 ] || [ ${#sigs[@]} -eq 0 ]; then
-            echo "artefact de mise à jour ou signature manquant" >&2
+          # Signatures de mise à jour, produites par `createUpdaterArtifacts`.
+          #
+          # Tauri v2 signe l'INSTALLEUR lui-même et dépose un `.sig` détaché à
+          # côté : `IdleWarden_x.y.z_x64-setup.exe` et `.exe.sig`. Il n'y a pas
+          # d'archive intermédiaire — le `.nsis.zip` était la forme de Tauri v1,
+          # et le chercher faisait échouer cette étape alors que le bundle avait
+          # parfaitement réussi.
+          #
+          # Leur absence reste une erreur et non un avertissement : sans elles
+          # la release est installable à la main mais invisible pour
+          # l'auto-update, ce qui ne se remarque qu'au moment où personne ne
+          # reçoit la version suivante.
+          sigs=(target/release/bundle/nsis/*.exe.sig)
+          if [ ${#sigs[@]} -eq 0 ]; then
+            echo "signature de mise à jour manquante" >&2
             ls -R target/release/bundle >&2 || true
             exit 1
           fi
 
-          printf 'à publier : %s\n' "${bundles[@]}" "${updaters[@]}" "${sigs[@]}"
+          printf 'à publier : %s\n' "${bundles[@]}" "${sigs[@]}"
           gh release upload "$TAG" \
-            "${bundles[@]}" "${updaters[@]}" "${sigs[@]}" \
+            "${bundles[@]}" "${sigs[@]}" \
             --clobber --repo "$GITHUB_REPOSITORY"
 
       # Sur un déclenchement manuel il n'y a pas de release à alimenter, mais
@@ -127,6 +133,5 @@ jobs:
           name: idlewarden-windows
           path: |
             target/release/bundle/nsis/*.exe
-            target/release/bundle/nsis/*.nsis.zip
-            target/release/bundle/nsis/*.nsis.zip.sig
+            target/release/bundle/nsis/*.exe.sig
           if-no-files-found: error


### PR DESCRIPTION
La release `desktop@v26.8.28` n'a **aucun artefact**, alors que sa construction a parfaitement réussi.

## Ce qui s'est passé

Le bundle a produit tout ce qu'il fallait :

```
Running makensis to produce …\IdleWarden_26.8.28_x64-setup.exe
Finished 2 bundles at:
Finished 2 updater signatures at:
```

C'est l'étape d'attachement qui a échoué, sur une condition que j'avais écrite de travers. Le `ls -R` de secours a donné la réponse :

```
target/release/bundle/nsis:
  IdleWarden_26.8.28_x64-setup.exe
  IdleWarden_26.8.28_x64-setup.exe.sig
```

**Il n'y a pas de `.nsis.zip`.** Tauri v2 signe l'installeur lui-même et dépose un `.sig` détaché à côté. L'archive intermédiaire que je cherchais est la forme de Tauri v1. Ma condition exigeait un fichier qui n'existe pas, donc l'étape sortait en erreur et la release restait vide.

Le garde-fou a fait son travail : l'échec a été bruyant et immédiatement diagnosticable, au lieu de publier une release silencieusement dépourvue de signature.

## Le correctif

La signature recherchée devient `*.exe.sig`. L'installeur `.exe` **est** l'artefact de mise à jour, il n'y a donc plus de troisième fichier à publier.

L'exigence est conservée : sans signature l'étape échoue, parce qu'une release installable mais invisible pour l'auto-update ne se remarque qu'au moment où personne ne reçoit la version suivante.

## Après le merge

Relancer le workflow sur `desktop@v26.8.28` attachera l'installeur et sa signature à la release existante — `--clobber` rend l'opération rejouable.

## Ce que ça ne règle pas

La page `/download` du site n'offre toujours aucun lien : elle affiche « Le coffre est encore vide », texte écrit avant qu'une construction n'existe. Même avec une release garnie, rien ne sera téléchargeable depuis le site tant que cette page n'aura pas été mise à jour. C'est un changement distinct, à faire dans `idlewarden-cloud`.