### PR TITLE
fix(desktop): let a manual run repair an empty release

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -84,11 +84,22 @@ jobs:
       # c'est un workspace Cargo, et tous les crates partagent le même
       # répertoire de sortie. Tauri l'annonce d'ailleurs en fin de bundle
       # (« Finished 2 bundles at: …/target/release/bundle/… »).
+      # Le déclenchement manuel attache lui aussi, dès lors qu'on lui a donné un
+      # tag de release. C'est la raison d'être de ce chemin : réparer une
+      # publication ratée. Le limiter à l'évènement `release` le rendait
+      # incapable de traiter exactement le cas pour lequel on s'en sert — une
+      # release existante et vide, dont l'exécution automatique a échoué.
+      #
+      # Un `workflow_dispatch` sur une branche (`main`, une branche de test) ne
+      # correspond à aucune release : la condition l'écarte, et l'étape suivante
+      # conserve alors l'installeur en artefact.
       - name: Attacher l'installeur à la release
-        if: github.event_name == 'release'
+        if: >-
+          github.event_name == 'release' ||
+          startsWith(inputs.tag, 'desktop@v')
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -127,7 +138,9 @@ jobs:
       # l'artefact reste récupérable : c'est ce qui permet de tester une
       # construction sans publier quoi que ce soit.
       - name: Conserver l'installeur comme artefact
-        if: github.event_name == 'workflow_dispatch'
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          !startsWith(inputs.tag, 'desktop@v')
         uses: actions/upload-artifact@v4
         with:
           name: idlewarden-windows


### PR DESCRIPTION
Le déclenchement manuel existe pour réparer une publication ratée, et il est précisément incapable de le faire.

`desktop@v26.8.28` est une release vide : son exécution automatique a échoué sur un `.nsis.zip` que Tauri v2 ne produit pas, corrigé par #28. Relancer le workflow à la main sur ce tag reconstruit tout correctement — puis conserve l'installeur en artefact de run et **laisse la release vide**, parce que l'étape d'attachement est conditionnée à `github.event_name == 'release'`.

Le seul recours restant est un `gh release upload` hors CI, ce qui contourne le chemin qu'on vient de corriger au lieu de l'exercer.

## Le correctif

L'attachement se déclenche aussi sur un lancement manuel dont l'entrée `tag` est un tag de release :

```yaml
if: >-
  github.event_name == 'release' ||
  startsWith(inputs.tag, 'desktop@v')
```

Le préfixe est le discriminant : un `workflow_dispatch` sur `main` ou sur une branche de test ne correspond à aucune release, la condition l'écarte, et l'installeur reste un simple artefact — comportement inchangé pour ce cas.

L'étape d'artefact reçoit la condition inverse, pour que les deux ne se déclenchent jamais ensemble.

`gh release upload --clobber` rend l'opération rejouable : réparer une release deux fois de suite est sans effet de bord.

## Vérification

YAML valide. Le reste ne se vérifie qu'à l'exécution, et c'est l'objet de la relance qui suivra le merge : elle garnira `desktop@v26.8.28`, ce qui est aussi le test du correctif.