### PR TITLE
test(core): pin the wire format so the UI's types cannot drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Format
         run: pnpm format:check
+      - name: Typecheck
+        run: pnpm typecheck
       - name: Build
         run: pnpm build
 

--- a/apps/desktop/.prettierignore
+++ b/apps/desktop/.prettierignore
@@ -3,3 +3,4 @@ dist
 src-tauri/target
 src-tauri/gen
 pnpm-lock.yaml
+src/app/session/wire-format.generated.ts

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit",
     "watch": "ng build --watch --configuration development",
     "tauri": "tauri",
     "format": "prettier --write .",

--- a/apps/desktop/src/app/session/session.model.ts
+++ b/apps/desktop/src/app/session/session.model.ts
@@ -19,33 +19,51 @@ export type Command =
 export type RefusalKind =
   "no_game_ready" | "halted" | "not_running" | "not_paused" | "running_dry_run_change";
 
+export interface Refusal {
+  refusal: RefusalKind;
+}
+
 export interface Refused {
-  refusal: { refusal: RefusalKind };
+  refusal: Refusal;
   message: string;
 }
 
-/// Mirrors `idlewarden_core::Event`. Hand-copied like the rest of this file,
-/// which is what #18 is about.
+export type SignalValue =
+  | { type: "bool"; value: boolean }
+  | { type: "int"; value: number }
+  | { type: "float"; value: number }
+  | { type: "ratio"; value: number }
+  | { type: "text"; value: string }
+  | { type: "point"; value: { x: number; y: number } }
+  | { type: "rect"; value: { x: number; y: number; w: number; h: number } }
+  | { type: "enum"; value: string };
+
+export interface Intent {
+  name: string;
+  params: Record<string, SignalValue>;
+}
+
+export type ActionOutcome =
+  | { outcome: "succeeded" }
+  | { outcome: "failed"; reason: string }
+  | { outcome: "rejected"; reason: string }
+  | { outcome: "aborted" }
+  | { outcome: "timed_out"; after_ms: number };
+
 export type SessionEvent =
   | { event: "game_detected"; plugin: string; window_title: string }
   | { event: "game_lost" }
   | { event: "plugin_loaded"; plugin: string; version: string }
   | { event: "plugin_failed"; plugin: string; reason: string }
   | { event: "observed"; observation: Observation }
-  | { event: "intent_proposed"; intent: { name: string } }
-  | { event: "intent_rejected"; intent: { name: string }; reason: string }
-  | { event: "action_started"; intent: { name: string } }
-  | { event: "action_finished"; intent: { name: string }; outcome: unknown }
+  | { event: "intent_proposed"; intent: Intent }
+  | { event: "intent_rejected"; intent: Intent; reason: string }
+  | { event: "action_started"; intent: Intent }
+  | { event: "action_finished"; intent: Intent; outcome: ActionOutcome }
   | { event: "agent_paused"; reason: string }
   | { event: "agent_resumed" }
   | { event: "kill_switch" }
   | { event: "error"; message: string };
-
-/// `idlewarden_plugin_api::Value`, tagged externally by serde.
-export interface SignalValue {
-  type: "bool" | "int" | "float" | "ratio" | "text" | "point" | "rect";
-  value: unknown;
-}
 
 export interface Signal {
   id: string;

--- a/apps/desktop/src/app/session/wire-format.generated.ts
+++ b/apps/desktop/src/app/session/wire-format.generated.ts
@@ -1,0 +1,307 @@
+import type {
+  Command,
+  Refusal,
+  Session,
+  SessionEvent,
+  SignalValue,
+} from "./session.model";
+
+export const COMMANDS: readonly Command[] = [
+  {
+    "command": "start",
+    "plugin": "dev.idlewarden.example-game",
+    "profile": "default"
+  },
+  {
+    "command": "stop"
+  },
+  {
+    "command": "pause"
+  },
+  {
+    "command": "resume"
+  },
+  {
+    "command": "set_dry_run",
+    "enabled": false
+  },
+];
+
+export const EVENTS: readonly SessionEvent[] = [
+  {
+    "event": "game_detected",
+    "plugin": "dev.idlewarden.example-game",
+    "window_title": "Example Game"
+  },
+  {
+    "event": "game_lost"
+  },
+  {
+    "event": "plugin_loaded",
+    "plugin": "dev.idlewarden.example-game",
+    "version": "26.9.5"
+  },
+  {
+    "event": "plugin_failed",
+    "plugin": "dev.idlewarden.broken",
+    "reason": "rules.json is not valid JSON"
+  },
+  {
+    "event": "observed",
+    "observation": {
+      "frame_id": 42,
+      "captured_at_ms": 1250,
+      "signals": [
+        {
+          "id": "ui.screen_id",
+          "value": {
+            "type": "enum",
+            "value": "main"
+          },
+          "confidence": 0.93
+        },
+        {
+          "id": "progress.bar",
+          "value": {
+            "type": "ratio",
+            "value": 0.5
+          },
+          "confidence": 1.0
+        }
+      ]
+    }
+  },
+  {
+    "event": "intent_proposed",
+    "intent": {
+      "name": "collect_reward",
+      "params": {
+        "slot": {
+          "type": "int",
+          "value": 3
+        }
+      }
+    }
+  },
+  {
+    "event": "intent_rejected",
+    "intent": {
+      "name": "collect_reward",
+      "params": {
+        "slot": {
+          "type": "int",
+          "value": 3
+        }
+      }
+    },
+    "reason": "rate ceiling reached"
+  },
+  {
+    "event": "action_started",
+    "intent": {
+      "name": "collect_reward",
+      "params": {
+        "slot": {
+          "type": "int",
+          "value": 3
+        }
+      }
+    }
+  },
+  {
+    "event": "action_finished",
+    "intent": {
+      "name": "collect_reward",
+      "params": {
+        "slot": {
+          "type": "int",
+          "value": 3
+        }
+      }
+    },
+    "outcome": {
+      "outcome": "succeeded"
+    }
+  },
+  {
+    "event": "action_finished",
+    "intent": {
+      "name": "collect_reward",
+      "params": {
+        "slot": {
+          "type": "int",
+          "value": 3
+        }
+      }
+    },
+    "outcome": {
+      "outcome": "failed",
+      "reason": "the post-condition did not hold"
+    }
+  },
+  {
+    "event": "action_finished",
+    "intent": {
+      "name": "collect_reward",
+      "params": {
+        "slot": {
+          "type": "int",
+          "value": 3
+        }
+      }
+    },
+    "outcome": {
+      "outcome": "rejected",
+      "reason": "the window lost focus"
+    }
+  },
+  {
+    "event": "action_finished",
+    "intent": {
+      "name": "collect_reward",
+      "params": {
+        "slot": {
+          "type": "int",
+          "value": 3
+        }
+      }
+    },
+    "outcome": {
+      "outcome": "aborted"
+    }
+  },
+  {
+    "event": "action_finished",
+    "intent": {
+      "name": "collect_reward",
+      "params": {
+        "slot": {
+          "type": "int",
+          "value": 3
+        }
+      }
+    },
+    "outcome": {
+      "outcome": "timed_out",
+      "after_ms": 3000
+    }
+  },
+  {
+    "event": "agent_paused",
+    "reason": "confidence dropped below the floor"
+  },
+  {
+    "event": "agent_resumed"
+  },
+  {
+    "event": "kill_switch"
+  },
+  {
+    "event": "error",
+    "message": "capture backend unavailable"
+  },
+];
+
+export const SESSIONS: readonly Session[] = [
+  {
+    "state": "searching",
+    "dry_run": true,
+    "actions_taken": 0,
+    "last_reason": null,
+    "plugin": null,
+    "profile": null
+  },
+  {
+    "state": "ready",
+    "dry_run": true,
+    "actions_taken": 0,
+    "last_reason": null,
+    "plugin": null,
+    "profile": null
+  },
+  {
+    "state": "running",
+    "dry_run": false,
+    "actions_taken": 12,
+    "last_reason": null,
+    "plugin": "dev.idlewarden.example-game",
+    "profile": "default"
+  },
+  {
+    "state": "paused",
+    "dry_run": false,
+    "actions_taken": 12,
+    "last_reason": "confidence dropped below the floor",
+    "plugin": "dev.idlewarden.example-game",
+    "profile": "default"
+  },
+  {
+    "state": "halted",
+    "dry_run": true,
+    "actions_taken": 0,
+    "last_reason": null,
+    "plugin": null,
+    "profile": null
+  },
+];
+
+export const REFUSALS: readonly Refusal[] = [
+  {
+    "refusal": "no_game_ready"
+  },
+  {
+    "refusal": "halted"
+  },
+  {
+    "refusal": "not_running"
+  },
+  {
+    "refusal": "not_paused"
+  },
+  {
+    "refusal": "running_dry_run_change"
+  },
+];
+
+export const SIGNAL_VALUES: readonly SignalValue[] = [
+  {
+    "type": "bool",
+    "value": true
+  },
+  {
+    "type": "int",
+    "value": -7
+  },
+  {
+    "type": "float",
+    "value": 1.5
+  },
+  {
+    "type": "ratio",
+    "value": 0.25
+  },
+  {
+    "type": "text",
+    "value": "gold"
+  },
+  {
+    "type": "point",
+    "value": {
+      "x": 0.5,
+      "y": 0.75
+    }
+  },
+  {
+    "type": "rect",
+    "value": {
+      "x": 0.1,
+      "y": 0.2,
+      "w": 0.3,
+      "h": 0.4
+    }
+  },
+  {
+    "type": "enum",
+    "value": "main"
+  },
+];

--- a/crates/core/tests/wire_format.rs
+++ b/crates/core/tests/wire_format.rs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Pins the JSON the UI actually receives.
+//!
+//! The desktop app restates the Core's wire types by hand (ADR-0004 keeps
+//! `ts-rs`/`specta` derives out of this crate), so nothing used to notice when
+//! the two drifted. This test serialises one value of every variant the UI can
+//! see and writes it as a TypeScript module the app type-checks against its
+//! hand-written model. Rename a field here and either this test fails, or the
+//! desktop `typecheck` does.
+//!
+//! Regenerate with `UPDATE_WIRE_FORMAT=1 cargo test -p idlewarden-core`.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use idlewarden_core::{Command, Event, Refusal, Session, SessionState};
+use idlewarden_plugin_api::{
+    ActionOutcome, Confidence, Intent, Observation, PluginId, Signal, SignalId, Value,
+};
+
+fn generated_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../apps/desktop/src/app/session/wire-format.generated.ts")
+}
+
+fn intent() -> Intent {
+    let mut params = BTreeMap::new();
+    params.insert("slot".to_owned(), Value::Int(3));
+    Intent {
+        name: "collect_reward".to_owned(),
+        params,
+    }
+}
+
+fn observation() -> Observation {
+    Observation {
+        frame_id: 42,
+        captured_at_ms: 1_250,
+        signals: vec![
+            Signal {
+                id: SignalId("ui.screen_id".to_owned()),
+                value: Value::Enum("main".to_owned()),
+                confidence: Confidence::new(0.93),
+            },
+            Signal {
+                id: SignalId("progress.bar".to_owned()),
+                value: Value::Ratio(0.5),
+                confidence: Confidence::CERTAIN,
+            },
+        ],
+    }
+}
+
+fn every_value() -> Vec<Value> {
+    vec![
+        Value::Bool(true),
+        Value::Int(-7),
+        Value::Float(1.5),
+        Value::Ratio(0.25),
+        Value::Text("gold".to_owned()),
+        Value::Point { x: 0.5, y: 0.75 },
+        Value::Rect {
+            x: 0.1,
+            y: 0.2,
+            w: 0.3,
+            h: 0.4,
+        },
+        Value::Enum("main".to_owned()),
+    ]
+}
+
+fn every_event() -> Vec<Event> {
+    vec![
+        Event::GameDetected {
+            plugin: PluginId("dev.idlewarden.example-game".to_owned()),
+            window_title: "Example Game".to_owned(),
+        },
+        Event::GameLost,
+        Event::PluginLoaded {
+            plugin: PluginId("dev.idlewarden.example-game".to_owned()),
+            version: "26.9.5".to_owned(),
+        },
+        Event::PluginFailed {
+            plugin: PluginId("dev.idlewarden.broken".to_owned()),
+            reason: "rules.json is not valid JSON".to_owned(),
+        },
+        Event::Observed {
+            observation: observation(),
+        },
+        Event::IntentProposed { intent: intent() },
+        Event::IntentRejected {
+            intent: intent(),
+            reason: "rate ceiling reached".to_owned(),
+        },
+        Event::ActionStarted { intent: intent() },
+        Event::ActionFinished {
+            intent: intent(),
+            outcome: ActionOutcome::Succeeded,
+        },
+        Event::ActionFinished {
+            intent: intent(),
+            outcome: ActionOutcome::Failed {
+                reason: "the post-condition did not hold".to_owned(),
+            },
+        },
+        Event::ActionFinished {
+            intent: intent(),
+            outcome: ActionOutcome::Rejected {
+                reason: "the window lost focus".to_owned(),
+            },
+        },
+        Event::ActionFinished {
+            intent: intent(),
+            outcome: ActionOutcome::Aborted,
+        },
+        Event::ActionFinished {
+            intent: intent(),
+            outcome: ActionOutcome::TimedOut { after_ms: 3_000 },
+        },
+        Event::AgentPaused {
+            reason: "confidence dropped below the floor".to_owned(),
+        },
+        Event::AgentResumed,
+        Event::KillSwitch,
+        Event::Error {
+            message: "capture backend unavailable".to_owned(),
+        },
+    ]
+}
+
+fn every_command() -> Vec<Command> {
+    vec![
+        Command::Start {
+            plugin: PluginId("dev.idlewarden.example-game".to_owned()),
+            profile: "default".to_owned(),
+        },
+        Command::Stop,
+        Command::Pause,
+        Command::Resume,
+        Command::SetDryRun { enabled: false },
+    ]
+}
+
+fn every_session() -> Vec<Session> {
+    let running = Session {
+        state: SessionState::Running,
+        dry_run: false,
+        actions_taken: 12,
+        plugin: Some(PluginId("dev.idlewarden.example-game".to_owned())),
+        profile: Some("default".to_owned()),
+        ..Session::default()
+    };
+
+    let paused = Session {
+        state: SessionState::Paused,
+        last_reason: Some("confidence dropped below the floor".to_owned()),
+        ..running.clone()
+    };
+
+    let ready = Session {
+        state: SessionState::Ready,
+        ..Session::default()
+    };
+
+    let halted = Session {
+        state: SessionState::Halted,
+        ..Session::default()
+    };
+
+    vec![Session::default(), ready, running, paused, halted]
+}
+
+fn every_refusal() -> Vec<Refusal> {
+    vec![
+        Refusal::NoGameReady,
+        Refusal::Halted,
+        Refusal::NotRunning,
+        Refusal::NotPaused,
+        Refusal::RunningDryRunChange,
+    ]
+}
+
+fn block<T: serde::Serialize>(name: &str, ts_type: &str, values: &[T]) -> String {
+    let rendered: Vec<String> = values
+        .iter()
+        .map(|value| {
+            let json = serde_json::to_string_pretty(value).expect("the wire types serialise");
+            json.lines()
+                .map(|line| format!("  {line}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .collect();
+
+    format!(
+        "export const {name}: readonly {ts_type}[] = [\n{},\n];\n",
+        rendered.join(",\n")
+    )
+}
+
+fn generate() -> String {
+    let mut out = String::from(
+        "import type {\n  Command,\n  Refusal,\n  Session,\n  SessionEvent,\n  SignalValue,\n} from \"./session.model\";\n\n",
+    );
+    out.push_str(&block("COMMANDS", "Command", &every_command()));
+    out.push('\n');
+    out.push_str(&block("EVENTS", "SessionEvent", &every_event()));
+    out.push('\n');
+    out.push_str(&block("SESSIONS", "Session", &every_session()));
+    out.push('\n');
+    out.push_str(&block("REFUSALS", "Refusal", &every_refusal()));
+    out.push('\n');
+    out.push_str(&block("SIGNAL_VALUES", "SignalValue", &every_value()));
+    out
+}
+
+#[test]
+fn the_generated_wire_format_matches_what_the_core_serialises() {
+    let path = generated_path();
+    let generated = generate();
+
+    if std::env::var_os("UPDATE_WIRE_FORMAT").is_some() {
+        std::fs::write(&path, &generated).expect("the generated module could be written");
+        return;
+    }
+
+    let committed = std::fs::read_to_string(&path)
+        .unwrap_or_default()
+        .replace("\r\n", "\n");
+
+    assert_eq!(
+        committed, generated,
+        "the committed wire format is stale; regenerate it with \
+         `UPDATE_WIRE_FORMAT=1 cargo test -p idlewarden-core`"
+    );
+}
+
+#[test]
+fn every_event_variant_is_covered() {
+    let names: Vec<String> = every_event()
+        .iter()
+        .map(|event| {
+            serde_json::to_value(event).expect("events serialise")["event"]
+                .as_str()
+                .expect("every event carries its tag")
+                .to_owned()
+        })
+        .collect();
+
+    for expected in [
+        "game_detected",
+        "game_lost",
+        "plugin_loaded",
+        "plugin_failed",
+        "observed",
+        "intent_proposed",
+        "intent_rejected",
+        "action_started",
+        "action_finished",
+        "agent_paused",
+        "agent_resumed",
+        "kill_switch",
+        "error",
+    ] {
+        assert!(
+            names.iter().any(|name| name == expected),
+            "{expected} is not in the fixtures, so the UI's handling of it is unchecked"
+        );
+    }
+}
+
+#[test]
+fn every_value_variant_is_covered() {
+    let tags: Vec<String> = every_value()
+        .iter()
+        .map(|value| {
+            serde_json::to_value(value).expect("values serialise")["type"]
+                .as_str()
+                .expect("every value carries its tag")
+                .to_owned()
+        })
+        .collect();
+
+    for expected in [
+        "bool", "int", "float", "ratio", "text", "point", "rect", "enum",
+    ] {
+        assert!(
+            tags.iter().any(|tag| tag == expected),
+            "{expected} is not in the fixtures, so the UI's rendering of it is unchecked"
+        );
+    }
+}

--- a/docs/adr/0017-wire-format-fixtures.md
+++ b/docs/adr/0017-wire-format-fixtures.md
@@ -1,0 +1,74 @@
+# ADR-0017: The UI's types stay hand-written, and a generated fixture keeps them honest
+
+**Status:** Accepted · **Date:** 2026-09-07
+
+## Context
+
+`apps/desktop/src/app/session/session.model.ts` restates by hand every shape the
+Core serialises. Nothing checked that the two stayed in step, so renaming a field
+in `idlewarden_core` produced a runtime bug that both compilers were happy with.
+That is issue #18.
+
+The obvious fix is to generate the TypeScript from the Rust with `ts-rs` or
+`tauri-specta`. Both work by putting derive macros on the Core's types, which
+means the Core starts carrying annotations that exist purely for the desktop
+app's benefit. [ADR-0004](0004-ui-boundary.md) is explicit that the Core contains
+no UI code, and that this is what keeps a headless daemon a refactor rather than
+a rewrite. A `#[derive(TS)]` on `Event` is UI code in the Core, just spelled
+quietly.
+
+## Decision
+
+Keep `session.model.ts` hand-written. Add `crates/core/tests/wire_format.rs`,
+which serialises one value of **every** variant the UI can observe and writes it
+to `apps/desktop/src/app/session/wire-format.generated.ts` as typed constants:
+
+```ts
+export const EVENTS: readonly SessionEvent[] = [ … ];
+```
+
+The file is committed. The Rust test fails when the committed copy no longer
+matches what the Core serialises; `pnpm typecheck` in `apps/desktop` fails when
+the fixtures no longer satisfy the hand-written types. Both run in CI.
+
+## Why this catches drift in both directions
+
+A rename in the Core leaves the developer exactly two paths, and both are closed:
+
+* Regenerate the fixture, and `tsc` rejects it against the stale model.
+* Do not regenerate, and `cargo test -p idlewarden-core` rejects the stale file.
+
+Verified rather than assumed: renaming `window_title` to `windowTitle` in the
+fixture produces `TS2353: '"windowTitle"' does not exist in type
+'{ event: "game_detected"; … }'` and a failing `the_generated_wire_format_matches_what_the_core_serialises`.
+
+Two further tests assert that every `Event` tag and every `Value` tag appears in
+the fixtures, because a variant nobody sampled is a variant nobody checks. Adding
+a variant to the Core without sampling it fails those instead of passing silently.
+
+## What it found immediately
+
+The hand-written model was already wrong in two places, which is the argument for
+the mechanism better than any reasoning about it:
+
+* `SignalValue` was missing `enum`, the variant the example plugin's
+  `ui.screen_id` actually emits.
+* `Intent` was declared as `{ name: string }`, dropping `params` entirely, so
+  every intent parameter reaching the UI was invisible to the compiler.
+
+`ActionOutcome` was `unknown` and is now a real union.
+
+## Consequences
+
+* The Core keeps zero knowledge of TypeScript. The direction of the dependency is
+  unchanged: the app adapts to the Core, never the reverse.
+* Adding a variant means adding a sample. That is the cost, and it is the point:
+  the sample is what the UI's handling of that variant is checked against.
+* The generated file is in `.prettierignore`. It is written by a Rust test, and
+  making its formatter agree with Prettier byte for byte would be busywork with a
+  new way to fail.
+* This does not check behaviour, only shape. A field that keeps its name and
+  changes its meaning still passes, and no type system was going to catch that.
+* If the desktop app ever needs the full type surface rather than the wire
+  vocabulary, revisit generation. The tension with ADR-0004 would still be real,
+  but the trade would be a different one.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,4 @@ request against the ADR, not around it.
 | [0014](0014-bridge.md) | L3 bridges connect to a user-installed mod; the Core never injects | Accepted |
 | [0015](0015-calver-everywhere.md) | calver-short everywhere, including the contract | Accepted |
 | [0016](0016-branch-protection.md) | Two rulesets on `main`, and the release bot bypasses only one | Accepted |
+| [0017](0017-wire-format-fixtures.md) | The UI's types stay hand-written, and a generated fixture keeps them honest | Accepted |


### PR DESCRIPTION
## What this changes

Renaming a field in the Core used to be a runtime bug: `session.model.ts` restates
every wire shape by hand and nothing compared the two. Now it breaks a build.

`crates/core/tests/wire_format.rs` serialises one value of every `Command`,
`Event`, `Session`, `Refusal` and `Value` variant and writes
`apps/desktop/src/app/session/wire-format.generated.ts` as typed constants. The
Rust test fails when the committed copy is stale; `pnpm typecheck` fails when the
fixtures no longer satisfy the hand-written model. Both run in CI, so both ways
out of a rename are closed.

Verified rather than assumed: renaming `window_title` to `windowTitle` in the
fixture produces `TS2353: '"windowTitle"' does not exist in type
'{ event: "game_detected"; ... }'` and fails
`the_generated_wire_format_matches_what_the_core_serialises`.

It found two live bugs on the first run:

- `SignalValue` was missing `enum`, the variant the example plugin's
  `ui.screen_id` actually emits
- `Intent` was `{ name: string }`, so every intent parameter reaching the UI was
  invisible to the compiler

`ActionOutcome` was `unknown` and is now a real union.

## Which ADR governs it

[ADR-0017](docs/adr/0017-wire-format-fixtures.md), added here. It records why
`ts-rs` and `tauri-specta` were rejected: both work by putting derive macros on
the Core's types, which is UI code in the Core and contradicts
[ADR-0004](docs/adr/0004-ui-boundary.md).

Closes #18.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Commits signed off (`git commit -s`)
- [x] SPDX header on every new source file
- [x] No game-specific knowledge added under `crates/`, that belongs in a plugin
- [x] No `tauri::` outside `apps/desktop/`
