### PR TITLE
feat(desktop): add the Detect screen, showing which windows a plugin claims

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ pub fn run() {
             session::dispatch,
             session::engage_kill_switch,
             session::plugins,
+            session::window_candidates,
             session::set_intent_enabled,
             updates::update_settings,
             updates::set_update_channel,

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use idlewarden_capture::CaptureBackend;
 #[cfg(windows)]
 use idlewarden_capture::WindowsCapture;
-use idlewarden_core::detector::DesktopWindows;
+use idlewarden_core::detector::{Candidate, DesktopWindows};
 use idlewarden_core::{
     load_all, Command, Detector, Event, Governor, GovernorConfig, Parts, PluginBundle, Refusal,
     Runner, Session, SessionService, SessionState, DEFAULT_TICK,
@@ -42,6 +42,30 @@ pub struct PluginSummary {
     pub id: String,
     pub detected: bool,
     pub intents: Vec<IntentSummary>,
+}
+
+/// One window detection looked at, as the Detect screen renders it.
+#[derive(Debug, Serialize)]
+pub struct WindowCandidate {
+    pub title: String,
+    pub executable: String,
+    pub steam_appid: Option<u32>,
+    pub plugins: Vec<String>,
+}
+
+impl From<Candidate> for WindowCandidate {
+    fn from(candidate: Candidate) -> Self {
+        WindowCandidate {
+            title: candidate.window.title,
+            executable: candidate.window.executable,
+            steam_appid: candidate.window.steam_appid,
+            plugins: candidate
+                .plugins
+                .into_iter()
+                .map(|plugin| plugin.0)
+                .collect(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -283,6 +307,21 @@ pub fn dispatch(handle: State<'_, SessionHandle>, command: Command) -> Result<Se
     }
 
     Ok(inner.session.clone())
+}
+
+/// What detection saw on the last poll. Refreshing first means the screen
+/// shows the desktop as the Detector ruled on it, not a second enumeration
+/// describing a different moment.
+#[tauri::command]
+pub fn window_candidates(handle: State<'_, SessionHandle>) -> Vec<WindowCandidate> {
+    let mut inner = handle.0.lock().expect("session lock");
+    inner.refresh();
+    inner
+        .detector
+        .candidates()
+        .into_iter()
+        .map(WindowCandidate::from)
+        .collect()
 }
 
 #[tauri::command]

--- a/apps/desktop/src/app/app.component.css
+++ b/apps/desktop/src/app/app.component.css
@@ -110,3 +110,29 @@ aside .label {
   padding: 18px 18px 0;
   border-top: 2px solid var(--line);
 }
+
+aside nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+aside nav a {
+  padding: 7px 10px;
+  color: var(--muted);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+aside nav a:hover {
+  color: var(--text);
+}
+
+aside nav a.active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  background: var(--rule);
+}

--- a/apps/desktop/src/app/app.component.html
+++ b/apps/desktop/src/app/app.component.html
@@ -34,7 +34,17 @@
     <p class="hint">
       Les plugins se lisent dans le dossier de données de l'application.
     </p>
-    <p class="label bottom">Réglages</p>
+    <p class="label bottom">Écrans</p>
+    <nav>
+      @for (screen of screens; track screen.path) {
+        <a
+          [routerLink]="screen.path"
+          routerLinkActive="active"
+          [routerLinkActiveOptions]="{ exact: true }"
+          >{{ screen.label }}</a
+        >
+      }
+    </nav>
   </aside>
 
   <router-outlet />

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, inject } from "@angular/core";
-import { RouterOutlet } from "@angular/router";
+import { RouterLink, RouterLinkActive, RouterOutlet } from "@angular/router";
 
 import { OWL } from "./owl";
 import { PluginSummary } from "./session/session.model";
@@ -7,7 +7,7 @@ import { SessionService } from "./session/session.service";
 
 @Component({
   selector: "app-root",
-  imports: [RouterOutlet],
+  imports: [RouterLink, RouterLinkActive, RouterOutlet],
   templateUrl: "./app.component.html",
   styleUrl: "./app.component.css",
 })
@@ -16,6 +16,10 @@ export class AppComponent {
 
   readonly plugins = this.sessions.plugins;
   readonly owl = computed(() => OWL);
+  readonly screens = [
+    { path: "/", label: "Session" },
+    { path: "/detection", label: "Détection" },
+  ];
 
   stateOf(plugin: PluginSummary): string {
     if (!plugin.detected) {

--- a/apps/desktop/src/app/app.routes.ts
+++ b/apps/desktop/src/app/app.routes.ts
@@ -1,5 +1,9 @@
 import { Routes } from "@angular/router";
 
+import { DetectComponent } from "./detect/detect.component";
 import { SessionComponent } from "./session/session.component";
 
-export const routes: Routes = [{ path: "", component: SessionComponent }];
+export const routes: Routes = [
+  { path: "", component: SessionComponent },
+  { path: "detection", component: DetectComponent },
+];

--- a/apps/desktop/src/app/detect/detect.component.css
+++ b/apps/desktop/src/app/detect/detect.component.css
@@ -1,0 +1,89 @@
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+  padding: 26px 30px;
+  overflow-y: auto;
+}
+
+header .who h1 {
+  font-size: 17px;
+}
+
+header .status {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.windows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.windows li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 15em) minmax(0, 16em);
+  gap: 14px;
+  align-items: baseline;
+  padding: 10px 12px;
+  border: 1px solid var(--rule);
+  background: var(--panel);
+}
+
+.windows.quiet li {
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted);
+}
+
+.windows li.ambiguous {
+  border-color: var(--gold);
+}
+
+.title {
+  color: var(--bright);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.exe,
+.verdict {
+  font-size: 11px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.windows li:not(.ambiguous) .verdict {
+  color: var(--accent);
+}
+
+.windows li.ambiguous .verdict {
+  color: var(--gold);
+}
+
+.windows.quiet .verdict {
+  color: var(--muted);
+}
+
+.muted {
+  margin: 0;
+  color: var(--muted);
+  max-width: 62ch;
+}
+
+.footnote {
+  font-size: 11px;
+}

--- a/apps/desktop/src/app/detect/detect.component.html
+++ b/apps/desktop/src/app/detect/detect.component.html
@@ -1,0 +1,58 @@
+<main>
+  <header>
+    <div class="who">
+      <h1>Détection</h1>
+      <p class="status">
+        Ce que le Gardien voit sur ce bureau, et qui revendique quoi.
+      </p>
+    </div>
+  </header>
+
+  <section>
+    <p class="label">Fenêtres reconnues — {{ claimed().length }}</p>
+    @if (claimed().length === 0) {
+      <p class="muted">
+        Aucune fenêtre ouverte ne correspond à un plugin installé. C'est la raison la
+        plus courante d'une veille qui ne démarre pas.
+      </p>
+    } @else {
+      <ul class="windows">
+        @for (candidate of claimed(); track candidate.title + candidate.executable) {
+          <li [class.ambiguous]="ambiguous(candidate)">
+            <span class="title">{{ candidate.title }}</span>
+            <span class="exe">
+              {{ candidate.executable }}
+              @if (candidate.steam_appid !== null) {
+                · steam {{ candidate.steam_appid }}
+              }
+            </span>
+            <span class="verdict">{{ verdict(candidate) }}</span>
+          </li>
+        }
+      </ul>
+      @if (claimed().length > 1) {
+        <p class="muted footnote">
+          Plusieurs jeux connus sont ouverts en même temps. Le Gardien refuse de choisir
+          tant qu'il y a une ambiguïté.
+        </p>
+      }
+    }
+  </section>
+
+  <section>
+    <p class="label">Autres fenêtres — {{ unclaimed().length }}</p>
+    @if (unclaimed().length === 0) {
+      <p class="muted">Rien d'autre n'est ouvert.</p>
+    } @else {
+      <ul class="windows quiet">
+        @for (candidate of unclaimed(); track candidate.title + candidate.executable) {
+          <li>
+            <span class="title">{{ candidate.title }}</span>
+            <span class="exe">{{ candidate.executable }}</span>
+            <span class="verdict">aucun plugin</span>
+          </li>
+        }
+      </ul>
+    }
+  </section>
+</main>

--- a/apps/desktop/src/app/detect/detect.component.ts
+++ b/apps/desktop/src/app/detect/detect.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnDestroy, OnInit, computed, inject } from "@angular/core";
+
+import { WindowCandidate } from "../session/session.model";
+import { SessionService } from "../session/session.service";
+
+const POLL_MS = 1000;
+
+@Component({
+  selector: "app-detect",
+  templateUrl: "./detect.component.html",
+  styleUrl: "./detect.component.css",
+})
+export class DetectComponent implements OnInit, OnDestroy {
+  private readonly sessions = inject(SessionService);
+
+  readonly candidates = this.sessions.candidates;
+  readonly claimed = computed(() =>
+    this.candidates().filter((candidate) => candidate.plugins.length > 0),
+  );
+  readonly unclaimed = computed(() =>
+    this.candidates().filter((candidate) => candidate.plugins.length === 0),
+  );
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  ngOnInit(): void {
+    void this.sessions.refreshCandidates();
+    this.timer = setInterval(() => void this.sessions.refreshCandidates(), POLL_MS);
+  }
+
+  ngOnDestroy(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+    }
+  }
+
+  verdict(candidate: WindowCandidate): string {
+    if (candidate.plugins.length === 0) {
+      return "aucun plugin";
+    }
+    if (candidate.plugins.length === 1) {
+      return candidate.plugins[0];
+    }
+    return `${candidate.plugins.length} plugins revendiquent cette fenêtre`;
+  }
+
+  ambiguous(candidate: WindowCandidate): boolean {
+    return candidate.plugins.length > 1;
+  }
+}

--- a/apps/desktop/src/app/session/session.model.ts
+++ b/apps/desktop/src/app/session/session.model.ts
@@ -82,6 +82,13 @@ export interface IntentSummary {
   enabled: boolean;
 }
 
+export interface WindowCandidate {
+  title: string;
+  executable: string;
+  steam_appid: number | null;
+  plugins: string[];
+}
+
 export interface PluginSummary {
   id: string;
   detected: boolean;

--- a/apps/desktop/src/app/session/session.service.ts
+++ b/apps/desktop/src/app/session/session.service.ts
@@ -8,6 +8,7 @@ import {
   Refused,
   Session,
   SessionEvent,
+  WindowCandidate,
 } from "./session.model";
 
 @Injectable({ providedIn: "root" })
@@ -17,12 +18,14 @@ export class SessionService {
   private readonly recent = signal<readonly SessionEvent[]>([]);
   private readonly known = signal<readonly PluginSummary[]>([]);
   private readonly seen = signal<Observation | null>(null);
+  private readonly windows = signal<readonly WindowCandidate[]>([]);
 
   readonly session = this.current.asReadonly();
   readonly refusal = this.lastRefusal.asReadonly();
   readonly events = this.recent.asReadonly();
   readonly plugins = this.known.asReadonly();
   readonly observation = this.seen.asReadonly();
+  readonly candidates = this.windows.asReadonly();
 
   /// Reading the state is what drives detection on the Rust side, so this has
   /// to keep being called rather than run once at startup.
@@ -40,6 +43,10 @@ export class SessionService {
         [...published.reverse(), ...existing].slice(0, 200),
       );
     }
+  }
+
+  async refreshCandidates(): Promise<void> {
+    this.windows.set(await invoke<WindowCandidate[]>("window_candidates"));
   }
 
   async refreshPlugins(): Promise<void> {

--- a/crates/core/src/detector.rs
+++ b/crates/core/src/detector.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-use idlewarden_capture::{detect, Detection, GameWindow, WindowHandle};
+use idlewarden_capture::{detect, matches, Detection, GameWindow, WindowHandle};
 use idlewarden_plugin_api::{GameMatcher, PluginId};
 
 use crate::{Event, Session, SessionState};
@@ -10,11 +10,26 @@ pub trait WindowSource: Send {
     fn windows(&mut self) -> Vec<GameWindow>;
 }
 
+/// One window the last poll looked at, and every plugin that claims it.
+///
+/// `plugins` is a list rather than an option on purpose: two plugins claiming
+/// the same window is why a session refuses to start, and the Detect screen
+/// exists to make that visible instead of leaving it in the logs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    pub window: GameWindow,
+    pub plugins: Vec<PluginId>,
+}
+
 /// Moves a session between `Searching` and `Ready` as the game comes and goes.
 pub struct Detector {
     source: Box<dyn WindowSource>,
     plugins: Vec<(PluginId, GameMatcher)>,
     current: Option<WindowHandle>,
+    /// What the last poll enumerated. Kept so the UI can show the same list
+    /// detection ruled on, rather than enumerating the desktop a second time
+    /// and describing a different moment.
+    seen: Vec<GameWindow>,
 }
 
 impl Detector {
@@ -23,7 +38,25 @@ impl Detector {
             source,
             plugins,
             current: None,
+            seen: Vec::new(),
         }
+    }
+
+    /// Every window the last [`Detector::poll`] considered, each with the
+    /// plugins claiming it. Empty until the first poll.
+    pub fn candidates(&self) -> Vec<Candidate> {
+        self.seen
+            .iter()
+            .map(|window| Candidate {
+                window: window.clone(),
+                plugins: self
+                    .plugins
+                    .iter()
+                    .filter(|(_, matcher)| matches(matcher, window))
+                    .map(|(id, _)| id.clone())
+                    .collect(),
+            })
+            .collect()
     }
 
     /// The window the session is currently bound to, which is what a capture
@@ -37,14 +70,16 @@ impl Detector {
             return Vec::new();
         }
 
-        let windows = self.source.windows();
-        match detect(&self.plugins, &windows) {
+        self.seen = self.source.windows();
+        let windows = &self.seen;
+        match detect(&self.plugins, windows) {
             Detection::Found { plugin, window } => {
                 if self.current == Some(window) {
                     return Vec::new();
                 }
                 self.current = Some(window);
-                let window_title = windows
+                let window_title = self
+                    .seen
                     .iter()
                     .find(|candidate| candidate.handle == window)
                     .map(|candidate| candidate.title.clone())
@@ -236,6 +271,86 @@ mod tests {
             "a second plugin appearing must not tear down a running session"
         );
         assert_eq!(detector.window(), Some(WindowHandle(7)));
+    }
+
+    #[test]
+    fn candidates_are_empty_before_the_first_poll() {
+        let detector = detector(
+            vec![window(7, "Idle Quest", "game.exe")],
+            &[("quest", "game.exe")],
+        );
+
+        assert!(
+            detector.candidates().is_empty(),
+            "nothing has been enumerated yet, so claiming otherwise would be a guess"
+        );
+    }
+
+    #[test]
+    fn every_enumerated_window_is_reported_with_the_plugins_claiming_it() {
+        let mut session = Session::default();
+        let mut detector = detector(
+            vec![
+                window(7, "Idle Quest", "game.exe"),
+                window(8, "Notepad", "notepad.exe"),
+            ],
+            &[("quest", "game.exe")],
+        );
+        detector.poll(&mut session);
+
+        let candidates = detector.candidates();
+
+        assert_eq!(
+            candidates.len(),
+            2,
+            "unmatched windows must still be listed"
+        );
+        assert_eq!(
+            candidates[0].plugins,
+            vec![PluginId("quest".to_owned())],
+            "the matching window names its plugin"
+        );
+        assert!(
+            candidates[1].plugins.is_empty(),
+            "a window no plugin claims is what answers `why is nothing happening`"
+        );
+    }
+
+    #[test]
+    fn a_window_two_plugins_claim_reports_both() {
+        let mut session = Session::default();
+        let mut detector = detector(
+            vec![window(7, "Idle Quest", "game.exe")],
+            &[("quest", "game.exe"), ("clone", "game.exe")],
+        );
+        detector.poll(&mut session);
+
+        let candidates = detector.candidates();
+
+        assert_eq!(
+            candidates[0].plugins,
+            vec![PluginId("quest".to_owned()), PluginId("clone".to_owned())],
+            "the ambiguity that refused to start the session has to be visible"
+        );
+        assert_eq!(session.state, SessionState::Searching);
+    }
+
+    #[test]
+    fn candidates_follow_the_desktop_when_a_window_closes() {
+        let mut session = Session::default();
+        let mut detector = detector(
+            vec![window(7, "Idle Quest", "game.exe")],
+            &[("quest", "game.exe")],
+        );
+        detector.poll(&mut session);
+
+        detector.source = Box::new(Fixed(Vec::new()));
+        detector.poll(&mut session);
+
+        assert!(
+            detector.candidates().is_empty(),
+            "a closed window must not linger on the Detect screen"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this changes

"Why is nothing happening" was only answerable from logs the user does not have.
The Detect screen puts it on screen: every window detection enumerated, and which
plugins claim each one.

`Detector` now keeps the list its last poll ruled on and exposes it as
`candidates()`. The screen shows the same moment detection decided on, rather
than enumerating the desktop a second time and describing a different one.

`plugins` on a candidate is a list, not an option, on purpose: two plugins
claiming the same window is exactly why a session refuses to start
(`Detection::Ambiguous`), and that refusal is invisible otherwise. Ambiguous rows
are marked as such.

Tests cover the empty case before the first poll, unmatched windows still being
listed, the two-plugin case, and a closed window disappearing.

## Which ADR governs it

[ADR-0004](docs/adr/0004-ui-boundary.md): the attribution is computed in
`idlewarden_core` and the desktop only renders it. No matching logic in the app.

Closes #13.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Commits signed off (`git commit -s`)
- [x] SPDX header on every new source file
- [x] No game-specific knowledge added under `crates/`, that belongs in a plugin
- [x] No `tauri::` outside `apps/desktop/`
