### PR TITLE
feat(desktop): add the Activity screen, with Governor refusals as first-class rows

### DIFF
--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use idlewarden_capture::CaptureBackend;
 #[cfg(windows)]
@@ -20,6 +21,31 @@ use tauri::State;
 
 type Backends = (Box<dyn CaptureBackend>, Box<dyn InputBackend>);
 
+/// Events are drained by the UI, and nothing guarantees the UI is polling.
+/// Without a ceiling the buffer grows for as long as a session runs unwatched,
+/// so the oldest are dropped once it is reached.
+const MAX_BUFFERED_EVENTS: usize = 2_000;
+
+/// An event with the moment the desktop observed it.
+///
+/// The Core does not timestamp events, and it should not have to: what a log
+/// reader needs is wall-clock time, and the Core deliberately knows nothing
+/// about clocks it has not been handed. Stamping happens here, at the adapter,
+/// where a real clock exists.
+#[derive(Debug, Clone, Serialize)]
+pub struct Published {
+    pub at_ms: u64,
+    #[serde(flatten)]
+    pub event: Event,
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_millis() as u64)
+        .unwrap_or_default()
+}
+
 pub struct SessionHandle(Mutex<Inner>);
 
 struct Inner {
@@ -29,7 +55,7 @@ struct Inner {
     /// no session is running the detector maintains it directly.
     session: Session,
     service: Option<SessionService>,
-    events: Vec<Event>,
+    events: Vec<Published>,
     kill: KillSwitch,
     /// Intents the user switched off, keyed `plugin::intent`. The Governor is
     /// told about them when a session starts.
@@ -99,6 +125,12 @@ impl SessionHandle {
             .map(|bundle| (bundle.id.clone(), bundle.matcher.clone()))
             .collect();
 
+        let at_ms = now_ms();
+        let events = events
+            .into_iter()
+            .map(|event| Published { at_ms, event })
+            .collect();
+
         SessionHandle(Mutex::new(Inner {
             plugins,
             detector: Detector::new(Box::new(DesktopWindows), matchers),
@@ -114,10 +146,21 @@ impl SessionHandle {
 impl Inner {
     /// Detection while idle, published events while running. Called before
     /// anything reads the session, so the UI never sees a stale state.
+    fn publish(&mut self, events: impl IntoIterator<Item = Event>) {
+        let at_ms = now_ms();
+        self.events
+            .extend(events.into_iter().map(|event| Published { at_ms, event }));
+
+        if self.events.len() > MAX_BUFFERED_EVENTS {
+            let overflow = self.events.len() - MAX_BUFFERED_EVENTS;
+            self.events.drain(..overflow);
+        }
+    }
+
     fn refresh(&mut self) {
         if self.service.is_none() {
             let found = self.detector.poll(&mut self.session);
-            self.events.extend(found);
+            self.publish(found);
             return;
         }
 
@@ -130,7 +173,7 @@ impl Inner {
         for event in &published {
             project(&mut self.session, event);
         }
-        self.events.extend(published);
+        self.publish(published);
 
         if self.session.state == SessionState::Halted {
             self.service = None;
@@ -214,7 +257,7 @@ impl Inner {
             Ok(backends) => backends,
             Err(reason) => {
                 self.session.pause(reason.clone());
-                self.events.push(Event::Error { message: reason });
+                self.publish([Event::Error { message: reason }]);
                 return Ok(());
             }
         };
@@ -280,7 +323,7 @@ pub fn session_state(handle: State<'_, SessionHandle>) -> Session {
 }
 
 #[tauri::command]
-pub fn session_events(handle: State<'_, SessionHandle>) -> Vec<Event> {
+pub fn session_events(handle: State<'_, SessionHandle>) -> Vec<Published> {
     let mut inner = handle.0.lock().expect("session lock");
     inner.refresh();
     std::mem::take(&mut inner.events)
@@ -356,6 +399,66 @@ pub fn engage_kill_switch(handle: State<'_, SessionHandle>) -> Session {
     inner.kill.engage();
     inner.session.state = SessionState::Halted;
     inner.service = None;
-    inner.events.push(Event::KillSwitch);
+    inner.publish([Event::KillSwitch]);
     inner.session.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inner() -> Inner {
+        let empty = std::env::temp_dir().join("idlewarden-no-plugins-here");
+        let handle = SessionHandle::new(empty);
+        let mut inner = handle.0.into_inner().expect("session lock");
+        inner.events.clear();
+        inner
+    }
+
+    #[test]
+    fn published_events_carry_the_moment_they_were_observed() {
+        let mut inner = inner();
+
+        inner.publish([Event::KillSwitch]);
+
+        assert_eq!(inner.events.len(), 1);
+        assert!(
+            inner.events[0].at_ms > 1_700_000_000_000,
+            "an event without a real wall-clock stamp cannot answer `why at 3am`"
+        );
+    }
+
+    #[test]
+    fn the_buffer_drops_the_oldest_rather_than_growing_without_bound() {
+        let mut inner = inner();
+
+        for index in 0..MAX_BUFFERED_EVENTS + 50 {
+            inner.publish([Event::Error {
+                message: index.to_string(),
+            }]);
+        }
+
+        assert_eq!(
+            inner.events.len(),
+            MAX_BUFFERED_EVENTS,
+            "a session nobody is watching must not grow the buffer forever"
+        );
+
+        let first = match &inner.events[0].event {
+            Event::Error { message } => message.clone(),
+            other => panic!("unexpected event {other:?}"),
+        };
+        assert_eq!(first, "50", "the oldest events are the ones dropped");
+    }
+
+    #[test]
+    fn draining_the_buffer_leaves_it_empty_for_the_next_poll() {
+        let mut inner = inner();
+        inner.publish([Event::AgentResumed, Event::KillSwitch]);
+
+        let drained = std::mem::take(&mut inner.events);
+
+        assert_eq!(drained.len(), 2);
+        assert!(inner.events.is_empty());
+    }
 }

--- a/apps/desktop/src/app/activity/activity.component.css
+++ b/apps/desktop/src/app/activity/activity.component.css
@@ -1,0 +1,131 @@
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 26px 30px;
+  overflow-y: auto;
+}
+
+header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+header .who h1 {
+  font-size: 17px;
+}
+
+header .status {
+  margin: 6px 0 0;
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.filters {
+  display: flex;
+  gap: 6px;
+}
+
+.filters button {
+  padding: 6px 12px;
+}
+
+.filters button.on {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.note {
+  margin: 0;
+  padding: 9px 12px;
+  border-left: 2px solid var(--gold);
+  background: var(--panel);
+  color: var(--text);
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.timeline li {
+  display: grid;
+  grid-template-columns: 6.5em minmax(0, 12em) minmax(0, 14em) minmax(0, 1fr);
+  gap: 14px;
+  align-items: baseline;
+  padding: 7px 12px;
+  border-left: 2px solid var(--rule);
+}
+
+.timeline li:nth-child(odd) {
+  background: var(--panel);
+}
+
+.at {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.intent {
+  color: var(--bright);
+}
+
+.what,
+.detail {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+li[data-grade="proposed"] {
+  border-left-color: var(--line);
+}
+
+li[data-grade="proposed"] .what {
+  color: var(--text);
+}
+
+li[data-grade="allowed"] {
+  border-left-color: var(--accent);
+}
+
+li[data-grade="allowed"] .what {
+  color: var(--accent);
+}
+
+li[data-grade="refused"] {
+  border-left-color: var(--gold);
+}
+
+li[data-grade="refused"] .what {
+  color: var(--gold);
+}
+
+li[data-grade="failed"] {
+  border-left-color: var(--danger);
+}
+
+li[data-grade="failed"] .what {
+  color: var(--danger);
+}
+
+li[data-grade="context"] .what,
+li[data-grade="context"] .intent {
+  color: var(--muted);
+}
+
+.muted {
+  margin: 0;
+  color: var(--muted);
+}

--- a/apps/desktop/src/app/activity/activity.component.html
+++ b/apps/desktop/src/app/activity/activity.component.html
@@ -1,0 +1,46 @@
+<main>
+  <header>
+    <div class="who">
+      <h1>Activité</h1>
+      <p class="status">
+        Ce que l'agent a proposé, ce que le Gouverneur en a fait, et comment ça s'est
+        terminé.
+      </p>
+    </div>
+    <div class="filters">
+      @for (choice of filters; track choice.key) {
+        <button
+          type="button"
+          [class.on]="filter() === choice.key"
+          (click)="setFilter(choice.key)"
+        >
+          {{ choice.label }}
+        </button>
+      }
+    </div>
+  </header>
+
+  @if (refusalCount() > 0) {
+    <p class="note">
+      {{ refusalCount() }} intention(s) refusée(s). Une veille qui ne fait rien n'est
+      pas forcément une veille inactive.
+    </p>
+  }
+
+  @if (shown().length === 0) {
+    <p class="muted">
+      Rien à afficher. Les événements arrivent dès qu'une veille démarre.
+    </p>
+  } @else {
+    <ol class="timeline">
+      @for (entry of shown(); track $index) {
+        <li [attr.data-grade]="entry.grade">
+          <span class="at">{{ clock(entry.at_ms) }}</span>
+          <span class="intent">{{ entry.intent ?? "—" }}</span>
+          <span class="what">{{ entry.what }}</span>
+          <span class="detail">{{ entry.detail ?? "" }}</span>
+        </li>
+      }
+    </ol>
+  }
+</main>

--- a/apps/desktop/src/app/activity/activity.component.ts
+++ b/apps/desktop/src/app/activity/activity.component.ts
@@ -1,0 +1,187 @@
+import { Component, computed, inject, signal } from "@angular/core";
+
+import { ActionOutcome, PublishedEvent } from "../session/session.model";
+import { SessionService } from "../session/session.service";
+
+type ActivityFilter = "all" | "intents" | "refusals" | "trouble";
+
+/// What a row means, which drives its colour and its place in a filter.
+type Grade = "proposed" | "allowed" | "refused" | "failed" | "context";
+
+interface ActivityRow {
+  at_ms: number;
+  grade: Grade;
+  intent: string | null;
+  what: string;
+  detail: string | null;
+}
+
+const INTENT_GRADES: readonly Grade[] = ["proposed", "allowed", "refused", "failed"];
+
+@Component({
+  selector: "app-activity",
+  templateUrl: "./activity.component.html",
+  styleUrl: "./activity.component.css",
+})
+export class ActivityComponent {
+  private readonly sessions = inject(SessionService);
+
+  readonly filter = signal<ActivityFilter>("all");
+  readonly filters: readonly { key: ActivityFilter; label: string }[] = [
+    { key: "all", label: "Tout" },
+    { key: "intents", label: "Intentions" },
+    { key: "refusals", label: "Refus" },
+    { key: "trouble", label: "Incidents" },
+  ];
+
+  readonly rows = computed(() => this.sessions.events().map((event) => row(event)));
+
+  readonly shown = computed(() => {
+    const rows = this.rows();
+    switch (this.filter()) {
+      case "all":
+        return rows;
+      case "intents":
+        return rows.filter((entry) => INTENT_GRADES.includes(entry.grade));
+      case "refusals":
+        return rows.filter((entry) => entry.grade === "refused");
+      case "trouble":
+        return rows.filter((entry) => entry.grade === "failed");
+    }
+  });
+
+  readonly refusalCount = computed(
+    () => this.rows().filter((entry) => entry.grade === "refused").length,
+  );
+
+  setFilter(filter: ActivityFilter): void {
+    this.filter.set(filter);
+  }
+
+  clock(at_ms: number): string {
+    return new Date(at_ms).toLocaleTimeString();
+  }
+}
+
+function outcome(result: ActionOutcome): {
+  grade: Grade;
+  what: string;
+  detail: string | null;
+} {
+  switch (result.outcome) {
+    case "succeeded":
+      return { grade: "allowed", what: "terminé", detail: null };
+    case "failed":
+      return { grade: "failed", what: "échoué", detail: result.reason };
+    case "rejected":
+      return { grade: "failed", what: "refusé à l'exécution", detail: result.reason };
+    case "aborted":
+      return { grade: "failed", what: "interrompu", detail: null };
+    case "timed_out":
+      return { grade: "failed", what: "expiré", detail: `après ${result.after_ms} ms` };
+  }
+}
+
+/// One event becomes one row. Rejected intents are rows like any other, which
+/// is the point of the screen: an agent that is refusing to act looks identical
+/// to an idle one unless the refusals are visible.
+function row(event: PublishedEvent): ActivityRow {
+  const at_ms = event.at_ms;
+
+  switch (event.event) {
+    case "intent_proposed":
+      return {
+        at_ms,
+        grade: "proposed",
+        intent: event.intent.name,
+        what: "proposé",
+        detail: null,
+      };
+    case "intent_rejected":
+      return {
+        at_ms,
+        grade: "refused",
+        intent: event.intent.name,
+        what: "refusé par le Gouverneur",
+        detail: event.reason,
+      };
+    case "action_started":
+      return {
+        at_ms,
+        grade: "allowed",
+        intent: event.intent.name,
+        what: "exécution",
+        detail: null,
+      };
+    case "action_finished": {
+      const result = outcome(event.outcome);
+      return { at_ms, intent: event.intent.name, ...result };
+    }
+    case "agent_paused":
+      return {
+        at_ms,
+        grade: "failed",
+        intent: null,
+        what: "agent en pause",
+        detail: event.reason,
+      };
+    case "agent_resumed":
+      return {
+        at_ms,
+        grade: "context",
+        intent: null,
+        what: "agent repris",
+        detail: null,
+      };
+    case "kill_switch":
+      return {
+        at_ms,
+        grade: "failed",
+        intent: null,
+        what: "coupe-circuit",
+        detail: null,
+      };
+    case "error":
+      return {
+        at_ms,
+        grade: "failed",
+        intent: null,
+        what: "erreur",
+        detail: event.message,
+      };
+    case "game_detected":
+      return {
+        at_ms,
+        grade: "context",
+        intent: null,
+        what: "jeu détecté",
+        detail: `${event.plugin} · ${event.window_title}`,
+      };
+    case "game_lost":
+      return { at_ms, grade: "context", intent: null, what: "jeu perdu", detail: null };
+    case "plugin_loaded":
+      return {
+        at_ms,
+        grade: "context",
+        intent: null,
+        what: "plugin chargé",
+        detail: event.plugin,
+      };
+    case "plugin_failed":
+      return {
+        at_ms,
+        grade: "failed",
+        intent: null,
+        what: "plugin en échec",
+        detail: `${event.plugin} · ${event.reason}`,
+      };
+    case "observed":
+      return {
+        at_ms,
+        grade: "context",
+        intent: null,
+        what: "observation",
+        detail: `${event.observation.signals.length} signaux`,
+      };
+  }
+}

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -19,6 +19,7 @@ export class AppComponent {
   readonly screens = [
     { path: "/", label: "Session" },
     { path: "/detection", label: "Détection" },
+    { path: "/activite", label: "Activité" },
   ];
 
   stateOf(plugin: PluginSummary): string {

--- a/apps/desktop/src/app/app.routes.ts
+++ b/apps/desktop/src/app/app.routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from "@angular/router";
 
+import { ActivityComponent } from "./activity/activity.component";
 import { DetectComponent } from "./detect/detect.component";
 import { SessionComponent } from "./session/session.component";
 
 export const routes: Routes = [
   { path: "", component: SessionComponent },
   { path: "detection", component: DetectComponent },
+  { path: "activite", component: ActivityComponent },
 ];

--- a/apps/desktop/src/app/detect/detect.component.ts
+++ b/apps/desktop/src/app/detect/detect.component.ts
@@ -1,16 +1,14 @@
-import { Component, OnDestroy, OnInit, computed, inject } from "@angular/core";
+import { Component, computed, inject } from "@angular/core";
 
 import { WindowCandidate } from "../session/session.model";
 import { SessionService } from "../session/session.service";
-
-const POLL_MS = 1000;
 
 @Component({
   selector: "app-detect",
   templateUrl: "./detect.component.html",
   styleUrl: "./detect.component.css",
 })
-export class DetectComponent implements OnInit, OnDestroy {
+export class DetectComponent {
   private readonly sessions = inject(SessionService);
 
   readonly candidates = this.sessions.candidates;
@@ -20,19 +18,6 @@ export class DetectComponent implements OnInit, OnDestroy {
   readonly unclaimed = computed(() =>
     this.candidates().filter((candidate) => candidate.plugins.length === 0),
   );
-
-  private timer: ReturnType<typeof setInterval> | null = null;
-
-  ngOnInit(): void {
-    void this.sessions.refreshCandidates();
-    this.timer = setInterval(() => void this.sessions.refreshCandidates(), POLL_MS);
-  }
-
-  ngOnDestroy(): void {
-    if (this.timer !== null) {
-      clearInterval(this.timer);
-    }
-  }
 
   verdict(candidate: WindowCandidate): string {
     if (candidate.plugins.length === 0) {

--- a/apps/desktop/src/app/session/session.component.ts
+++ b/apps/desktop/src/app/session/session.component.ts
@@ -1,11 +1,9 @@
-import { Component, OnDestroy, OnInit, computed, inject } from "@angular/core";
+import { Component, computed, inject } from "@angular/core";
 
 import { UpdatesComponent } from "../updates/updates.component";
 import { OWL } from "../owl";
-import { Session, SessionEvent, Signal } from "./session.model";
+import { PublishedEvent, Session, Signal } from "./session.model";
 import { SessionService } from "./session.service";
-
-const POLL_MS = 500;
 
 @Component({
   selector: "app-session",
@@ -13,7 +11,7 @@ const POLL_MS = 500;
   templateUrl: "./session.component.html",
   styleUrl: "./session.component.css",
 })
-export class SessionComponent implements OnInit, OnDestroy {
+export class SessionComponent {
   private readonly sessions = inject(SessionService);
 
   readonly session = this.sessions.session;
@@ -25,13 +23,6 @@ export class SessionComponent implements OnInit, OnDestroy {
   readonly intents = computed(
     () => this.sessions.plugins().find((plugin) => plugin.detected)?.intents ?? [],
   );
-
-  private timer: ReturnType<typeof setInterval> | null = null;
-
-  ngOnInit(): void {
-    void this.sessions.refresh();
-    this.timer = setInterval(() => void this.sessions.refresh(), POLL_MS);
-  }
 
   headline(session: Session): string {
     switch (session.state) {
@@ -74,17 +65,11 @@ export class SessionComponent implements OnInit, OnDestroy {
     void this.sessions.setIntentEnabled(plugin, intent, enabled);
   }
 
-  ngOnDestroy(): void {
-    if (this.timer !== null) {
-      clearInterval(this.timer);
-    }
-  }
-
   killSwitch(): void {
     void this.sessions.engageKillSwitch();
   }
 
-  describe(event: SessionEvent): string {
+  describe(event: PublishedEvent): string {
     switch (event.event) {
       case "game_detected":
         return `detected ${event.plugin} in "${event.window_title}"`;

--- a/apps/desktop/src/app/session/session.model.ts
+++ b/apps/desktop/src/app/session/session.model.ts
@@ -65,6 +65,10 @@ export type SessionEvent =
   | { event: "kill_switch" }
   | { event: "error"; message: string };
 
+/// A `SessionEvent` as the desktop hands it over: the Core's own payload plus
+/// the wall-clock moment the app observed it.
+export type PublishedEvent = SessionEvent & { at_ms: number };
+
 export interface Signal {
   id: string;
   value: SignalValue;

--- a/apps/desktop/src/app/session/session.service.ts
+++ b/apps/desktop/src/app/session/session.service.ts
@@ -5,17 +5,24 @@ import {
   Command,
   Observation,
   PluginSummary,
+  PublishedEvent,
   Refused,
   Session,
-  SessionEvent,
   WindowCandidate,
 } from "./session.model";
+
+const POLL_MS = 500;
+
+/// How many published events the app keeps. The Rust side caps its own buffer;
+/// this is the second half of the same decision, for a window left open for
+/// days.
+const MAX_EVENTS = 2000;
 
 @Injectable({ providedIn: "root" })
 export class SessionService {
   private readonly current = signal<Session | null>(null);
   private readonly lastRefusal = signal<Refused | null>(null);
-  private readonly recent = signal<readonly SessionEvent[]>([]);
+  private readonly recent = signal<readonly PublishedEvent[]>([]);
   private readonly known = signal<readonly PluginSummary[]>([]);
   private readonly seen = signal<Observation | null>(null);
   private readonly windows = signal<readonly WindowCandidate[]>([]);
@@ -27,12 +34,31 @@ export class SessionService {
   readonly observation = this.seen.asReadonly();
   readonly candidates = this.windows.asReadonly();
 
+  /// Polling lives here rather than in a screen because events are drained on
+  /// read: a screen that owns the timer stops draining the moment the user
+  /// navigates away, and the Activity timeline loses everything that happened
+  /// while they were elsewhere.
+  constructor() {
+    void this.tick();
+    setInterval(() => void this.tick(), POLL_MS);
+  }
+
+  private async tick(): Promise<void> {
+    try {
+      await this.refresh();
+      await this.refreshCandidates();
+    } catch {
+      // Outside the Tauri shell there is no bridge to talk to. Nothing can be
+      // done about it and saying so 120 times a minute helps nobody.
+    }
+  }
+
   /// Reading the state is what drives detection on the Rust side, so this has
   /// to keep being called rather than run once at startup.
   async refresh(): Promise<void> {
     this.current.set(await invoke<Session>("session_state"));
     await this.refreshPlugins();
-    const published = await invoke<SessionEvent[]>("session_events");
+    const published = await invoke<PublishedEvent[]>("session_events");
     if (published.length > 0) {
       const observed = published.filter((event) => event.event === "observed");
       const latest = observed[observed.length - 1];
@@ -40,7 +66,7 @@ export class SessionService {
         this.seen.set(latest.observation);
       }
       this.recent.update((existing) =>
-        [...published.reverse(), ...existing].slice(0, 200),
+        [...published.reverse(), ...existing].slice(0, MAX_EVENTS),
       );
     }
   }


### PR DESCRIPTION
## What this changes

Makes "why did it click there at 3am" answerable, which is the stated reason every
event is published. A timeline of proposals, Governor verdicts and outcomes, with
refused intents as rows like any other: an agent that is refusing to act looks
identical to an idle one unless the refusals are visible.

Two things had to be fixed underneath it.

**Events had no time.** They are stamped now, at the desktop adapter rather than
in the Core, which deliberately knows nothing about clocks it was not handed.
`session_events` returns `Published { at_ms, ...event }`.

**The buffer grew without bound.** `Inner.events` was a `Vec` drained only when
the UI read it, and the UI read it only while the Session screen was mounted. It
is capped at 2000 now, dropping oldest first.

Polling also moved out of the screens into `SessionService`. A screen that owns
the timer stops draining the moment the user navigates away, and the timeline
would lose everything that happened while they were elsewhere.

Filters: everything, intents only, refusals only, incidents.

## Which ADR governs it

[ADR-0004](docs/adr/0004-ui-boundary.md). The timestamp is added by the adapter,
not the Core, so the Core keeps no clock it did not ask for.

Closes #14.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Commits signed off (`git commit -s`)
- [x] SPDX header on every new source file
- [x] No game-specific knowledge added under `crates/`, that belongs in a plugin
- [x] No `tauri::` outside `apps/desktop/`
