### PR TITLE
feat(desktop): add the Logs screen, keeping tracing fields structured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-updater",
  "thiserror 2.0.20",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -1878,6 +1880,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2079,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -3168,6 +3185,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,6 +3829,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4088,6 +4123,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4231,6 +4292,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1"
 thiserror = "2"
 semver = { version = "1", features = ["serde"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry", "std"] }
 
 [profile.release]
 lto = "thin"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,8 @@ idlewarden-input.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 tauri = { version = "2", features = [] }
 # Télécharge, vérifie la signature minisign et remplace le binaire installé.
 # La vérification est le point important : sans elle, l'URL servie par

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@
 //! `idlewarden_core::Command` and hands `idlewarden_core` types back to the
 //! web view. No decision about a session is taken here.
 
+mod logs;
 mod session;
 mod updates;
 
@@ -20,13 +21,24 @@ fn plugin_root(app: &tauri::AppHandle) -> std::path::PathBuf {
 }
 
 pub fn run() {
+    use std::sync::Arc;
     use tauri::Manager;
+    use tracing_subscriber::prelude::*;
+
+    // Everything below DEBUG is noise the user cannot act on; the Logs screen
+    // filters the rest.
+    let buffered = Arc::new(logs::LogBuffer::default());
+    tracing_subscriber::registry()
+        .with(logs::BufferLayer::new(Arc::clone(&buffered)))
+        .with(tracing_subscriber::filter::LevelFilter::DEBUG)
+        .init();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .setup(|app| {
+        .setup(move |app| {
             app.manage(updates::Updates::new(app.handle()));
             app.manage(session::SessionHandle::new(plugin_root(app.handle())));
+            app.manage(Arc::clone(&buffered));
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -37,6 +49,7 @@ pub fn run() {
             session::plugins,
             session::window_candidates,
             session::set_intent_enabled,
+            logs::drain_logs,
             updates::update_settings,
             updates::set_update_channel,
             updates::check_for_update,

--- a/apps/desktop/src-tauri/src/logs.rs
+++ b/apps/desktop/src-tauri/src/logs.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MPL-2.0
+//! The `tracing` stream, kept in memory so the app can show it (#15).
+//!
+//! A packaged desktop app has no console, so structured logs that only reach
+//! stdout reach nobody. This buffers them instead, and keeps each field as a
+//! typed JSON value rather than folding everything into one formatted line:
+//! flattening on the way out is exactly what makes a structured log stop being
+//! worth having.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use serde_json::Value;
+use tauri::State;
+use tracing::field::{Field, Visit};
+use tracing::Subscriber;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+/// Records are drained by the UI, and nothing guarantees the UI is polling.
+const MAX_BUFFERED_LOGS: usize = 2_000;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LogRecord {
+    pub at_ms: u64,
+    pub level: String,
+    pub target: String,
+    pub message: String,
+    pub fields: BTreeMap<String, Value>,
+}
+
+#[derive(Default)]
+pub struct LogBuffer(Mutex<VecDeque<LogRecord>>);
+
+impl LogBuffer {
+    fn push(&self, record: LogRecord) {
+        let mut held = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if held.len() == MAX_BUFFERED_LOGS {
+            held.pop_front();
+        }
+        held.push_back(record);
+    }
+
+    pub fn drain(&self) -> Vec<LogRecord> {
+        let mut held = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        held.drain(..).collect()
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_millis() as u64)
+        .unwrap_or_default()
+}
+
+/// Collects an event's fields, keeping their types. `message` is pulled out
+/// because it is the one field every log line has and the UI renders on its
+/// own row.
+#[derive(Default)]
+struct Collect {
+    message: String,
+    fields: BTreeMap<String, Value>,
+}
+
+impl Collect {
+    fn put(&mut self, field: &Field, value: Value) {
+        if field.name() == "message" {
+            self.message = match value {
+                Value::String(text) => text,
+                other => other.to_string(),
+            };
+            return;
+        }
+        self.fields.insert(field.name().to_owned(), value);
+    }
+}
+
+impl Visit for Collect {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.put(field, Value::Bool(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.put(field, Value::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.put(field, Value::from(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.put(field, Value::from(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.put(field, Value::String(value.to_owned()));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.put(field, Value::String(format!("{value:?}")));
+    }
+}
+
+pub struct BufferLayer(Arc<LogBuffer>);
+
+impl BufferLayer {
+    pub fn new(buffer: Arc<LogBuffer>) -> Self {
+        BufferLayer(buffer)
+    }
+}
+
+impl<S: Subscriber> Layer<S> for BufferLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut collect = Collect::default();
+        event.record(&mut collect);
+
+        self.0.push(LogRecord {
+            at_ms: now_ms(),
+            level: event.metadata().level().to_string(),
+            target: event.metadata().target().to_owned(),
+            message: collect.message,
+            fields: collect.fields,
+        });
+    }
+}
+
+/// Everything buffered since the last call. Drains for the same reason the
+/// event stream does: the app accumulates its own history and the buffer here
+/// only has to survive between polls.
+#[tauri::command]
+pub fn drain_logs(buffer: State<'_, Arc<LogBuffer>>) -> Vec<LogRecord> {
+    buffer.drain()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::prelude::*;
+
+    fn capture(emit: impl FnOnce()) -> Vec<LogRecord> {
+        let buffer = Arc::new(LogBuffer::default());
+        let subscriber = tracing_subscriber::registry().with(BufferLayer::new(buffer.clone()));
+        tracing::subscriber::with_default(subscriber, emit);
+        buffer.drain()
+    }
+
+    #[test]
+    fn fields_keep_their_types_instead_of_being_folded_into_the_message() {
+        let records = capture(|| {
+            tracing::info!(
+                plugin = "example-game",
+                actions = 3u64,
+                dry_run = true,
+                "started"
+            );
+        });
+
+        assert_eq!(records.len(), 1);
+        let record = &records[0];
+        assert_eq!(record.message, "started");
+        assert_eq!(record.level, "INFO");
+        assert_eq!(
+            record.fields["plugin"],
+            Value::String("example-game".to_owned())
+        );
+        assert_eq!(
+            record.fields["actions"],
+            Value::from(3u64),
+            "a number that arrives as a string cannot be filtered or compared"
+        );
+        assert_eq!(record.fields["dry_run"], Value::Bool(true));
+    }
+
+    #[test]
+    fn the_target_is_kept_so_the_ui_can_filter_by_it() {
+        let records = capture(|| {
+            tracing::warn!(target: "idlewarden::governor", "rate ceiling reached");
+        });
+
+        assert_eq!(records[0].target, "idlewarden::governor");
+        assert_eq!(records[0].level, "WARN");
+    }
+
+    #[test]
+    fn the_buffer_drops_the_oldest_rather_than_growing_without_bound() {
+        let buffer = LogBuffer::default();
+
+        for index in 0..MAX_BUFFERED_LOGS + 10 {
+            buffer.push(LogRecord {
+                at_ms: 0,
+                level: "INFO".to_owned(),
+                target: "t".to_owned(),
+                message: index.to_string(),
+                fields: BTreeMap::new(),
+            });
+        }
+
+        let drained = buffer.drain();
+
+        assert_eq!(drained.len(), MAX_BUFFERED_LOGS);
+        assert_eq!(
+            drained[0].message, "10",
+            "the oldest records are the ones dropped"
+        );
+    }
+
+    #[test]
+    fn draining_twice_does_not_repeat_records() {
+        let buffer = Arc::new(LogBuffer::default());
+        let subscriber = tracing_subscriber::registry().with(BufferLayer::new(buffer.clone()));
+        tracing::subscriber::with_default(subscriber, || tracing::info!("once"));
+
+        assert_eq!(buffer.drain().len(), 1);
+        assert!(
+            buffer.drain().is_empty(),
+            "a second poll must not replay what the first already took"
+        );
+    }
+}

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -20,6 +20,7 @@ export class AppComponent {
     { path: "/", label: "Session" },
     { path: "/detection", label: "Détection" },
     { path: "/activite", label: "Activité" },
+    { path: "/journaux", label: "Journaux" },
   ];
 
   stateOf(plugin: PluginSummary): string {

--- a/apps/desktop/src/app/app.routes.ts
+++ b/apps/desktop/src/app/app.routes.ts
@@ -2,10 +2,12 @@ import { Routes } from "@angular/router";
 
 import { ActivityComponent } from "./activity/activity.component";
 import { DetectComponent } from "./detect/detect.component";
+import { LogsComponent } from "./logs/logs.component";
 import { SessionComponent } from "./session/session.component";
 
 export const routes: Routes = [
   { path: "", component: SessionComponent },
   { path: "detection", component: DetectComponent },
   { path: "activite", component: ActivityComponent },
+  { path: "journaux", component: LogsComponent },
 ];

--- a/apps/desktop/src/app/logs/logs.component.css
+++ b/apps/desktop/src/app/logs/logs.component.css
@@ -1,0 +1,151 @@
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 26px 30px;
+  overflow-y: auto;
+}
+
+header .who h1 {
+  font-size: 17px;
+}
+
+header .status {
+  margin: 6px 0 0;
+  color: var(--muted);
+  max-width: 66ch;
+}
+
+code {
+  color: var(--accent-soft);
+}
+
+.filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.levels {
+  display: flex;
+  gap: 4px;
+}
+
+.levels button {
+  padding: 6px 11px;
+}
+
+.levels button.on {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+input[type="search"] {
+  flex: 1 1 16em;
+  min-width: 12em;
+  font: inherit;
+  color: var(--text);
+  background: var(--panel);
+  border: 2px solid var(--line);
+  padding: 8px 12px;
+}
+
+input[type="search"]:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.records {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.records li {
+  display: grid;
+  grid-template-columns: 6.5em 4.5em minmax(0, 14em) minmax(0, 1fr);
+  gap: 12px;
+  align-items: baseline;
+  padding: 6px 12px;
+  border-left: 2px solid var(--rule);
+}
+
+.records li:nth-child(odd) {
+  background: var(--panel);
+}
+
+.at,
+.target {
+  color: var(--muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.level {
+  font-size: 10px;
+  letter-spacing: 1px;
+}
+
+.message {
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.field {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 10px;
+  font-size: 11px;
+}
+
+.field .key {
+  color: var(--muted);
+}
+
+.field .key::after {
+  content: "=";
+}
+
+.field .value {
+  color: var(--accent-soft);
+}
+
+li[data-level="ERROR"] {
+  border-left-color: var(--danger);
+}
+
+li[data-level="ERROR"] .level {
+  color: var(--danger);
+}
+
+li[data-level="WARN"] {
+  border-left-color: var(--gold);
+}
+
+li[data-level="WARN"] .level {
+  color: var(--gold);
+}
+
+li[data-level="INFO"] .level {
+  color: var(--accent);
+}
+
+li[data-level="DEBUG"] .level,
+li[data-level="TRACE"] .level {
+  color: var(--muted);
+}
+
+.muted {
+  margin: 0;
+  color: var(--muted);
+}
+
+.footnote {
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}

--- a/apps/desktop/src/app/logs/logs.component.html
+++ b/apps/desktop/src/app/logs/logs.component.html
@@ -1,0 +1,55 @@
+<main>
+  <header>
+    <div class="who">
+      <h1>Journaux</h1>
+      <p class="status">
+        Le flux <code>tracing</code> du Core, avec ses champs, dans l'application plutôt
+        que dans une console que tu n'as pas.
+      </p>
+    </div>
+  </header>
+
+  <div class="filters">
+    <div class="levels">
+      @for (level of levels; track level) {
+        <button type="button" [class.on]="floor() === level" (click)="setFloor(level)">
+          {{ level }}
+        </button>
+      }
+    </div>
+    <input
+      type="search"
+      [value]="target()"
+      (input)="setTarget($any($event.target).value)"
+      placeholder="filtrer par cible"
+      aria-label="filtrer par cible"
+    />
+  </div>
+
+  @if (targets().length > 0) {
+    <p class="muted footnote">Cibles vues : {{ targets().join(" · ") }}</p>
+  }
+
+  @if (shown().length === 0) {
+    <p class="muted">Rien à ce niveau. Le Core n'a encore rien émis.</p>
+  } @else {
+    <ol class="records">
+      @for (record of shown(); track $index) {
+        <li [attr.data-level]="record.level">
+          <span class="at">{{ clock(record.at_ms) }}</span>
+          <span class="level">{{ record.level }}</span>
+          <span class="target">{{ record.target }}</span>
+          <span class="message">
+            {{ record.message }}
+            @for (field of entries(record); track field.key) {
+              <span class="field">
+                <span class="key">{{ field.key }}</span>
+                <span class="value">{{ field.value }}</span>
+              </span>
+            }
+          </span>
+        </li>
+      }
+    </ol>
+  }
+</main>

--- a/apps/desktop/src/app/logs/logs.component.ts
+++ b/apps/desktop/src/app/logs/logs.component.ts
@@ -1,0 +1,56 @@
+import { Component, computed, inject, signal } from "@angular/core";
+
+import { LogLevel, LogRecord } from "../session/session.model";
+import { SessionService } from "../session/session.service";
+
+const ORDER: readonly LogLevel[] = ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+
+@Component({
+  selector: "app-logs",
+  templateUrl: "./logs.component.html",
+  styleUrl: "./logs.component.css",
+})
+export class LogsComponent {
+  private readonly sessions = inject(SessionService);
+
+  readonly levels = ORDER;
+  readonly floor = signal<LogLevel>("DEBUG");
+  readonly target = signal("");
+
+  readonly targets = computed(() => {
+    const seen = new Set(this.sessions.logs().map((record) => record.target));
+    return [...seen].sort();
+  });
+
+  readonly shown = computed(() => {
+    const depth = ORDER.indexOf(this.floor());
+    const needle = this.target().toLowerCase();
+    return this.sessions
+      .logs()
+      .filter((record) => ORDER.indexOf(record.level) <= depth)
+      .filter(
+        (record) => needle === "" || record.target.toLowerCase().includes(needle),
+      );
+  });
+
+  setFloor(level: LogLevel): void {
+    this.floor.set(level);
+  }
+
+  setTarget(value: string): void {
+    this.target.set(value);
+  }
+
+  clock(at_ms: number): string {
+    return new Date(at_ms).toLocaleTimeString();
+  }
+
+  /// Fields stay separate values rather than one formatted line, so a reader
+  /// can see which of them carried the surprise.
+  entries(record: LogRecord): { key: string; value: string }[] {
+    return Object.entries(record.fields).map(([key, value]) => ({
+      key,
+      value: typeof value === "string" ? value : JSON.stringify(value),
+    }));
+  }
+}

--- a/apps/desktop/src/app/session/session.model.ts
+++ b/apps/desktop/src/app/session/session.model.ts
@@ -86,6 +86,18 @@ export interface IntentSummary {
   enabled: boolean;
 }
 
+export type LogLevel = "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE";
+
+/// One `tracing` event. `fields` keeps the structured values the Core emitted
+/// rather than a rendered line, which is what makes them filterable.
+export interface LogRecord {
+  at_ms: number;
+  level: LogLevel;
+  target: string;
+  message: string;
+  fields: Record<string, unknown>;
+}
+
 export interface WindowCandidate {
   title: string;
   executable: string;

--- a/apps/desktop/src/app/session/session.service.ts
+++ b/apps/desktop/src/app/session/session.service.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 
 import {
   Command,
+  LogRecord,
   Observation,
   PluginSummary,
   PublishedEvent,
@@ -26,6 +27,7 @@ export class SessionService {
   private readonly known = signal<readonly PluginSummary[]>([]);
   private readonly seen = signal<Observation | null>(null);
   private readonly windows = signal<readonly WindowCandidate[]>([]);
+  private readonly buffered = signal<readonly LogRecord[]>([]);
 
   readonly session = this.current.asReadonly();
   readonly refusal = this.lastRefusal.asReadonly();
@@ -33,6 +35,7 @@ export class SessionService {
   readonly plugins = this.known.asReadonly();
   readonly observation = this.seen.asReadonly();
   readonly candidates = this.windows.asReadonly();
+  readonly logs = this.buffered.asReadonly();
 
   /// Polling lives here rather than in a screen because events are drained on
   /// read: a screen that owns the timer stops draining the moment the user
@@ -47,6 +50,7 @@ export class SessionService {
     try {
       await this.refresh();
       await this.refreshCandidates();
+      await this.refreshLogs();
     } catch {
       // Outside the Tauri shell there is no bridge to talk to. Nothing can be
       // done about it and saying so 120 times a minute helps nobody.
@@ -73,6 +77,15 @@ export class SessionService {
 
   async refreshCandidates(): Promise<void> {
     this.windows.set(await invoke<WindowCandidate[]>("window_candidates"));
+  }
+
+  async refreshLogs(): Promise<void> {
+    const drained = await invoke<LogRecord[]>("drain_logs");
+    if (drained.length > 0) {
+      this.buffered.update((existing) =>
+        [...drained.reverse(), ...existing].slice(0, MAX_EVENTS),
+      );
+    }
   }
 
   async refreshPlugins(): Promise<void> {


### PR DESCRIPTION
## What this changes

A packaged desktop app has no console, so structured logs that only reach stdout
reach nobody. There was no `tracing` subscriber installed at all, which means
every `tracing::` call in the Core was going nowhere.

Adds a `tracing_subscriber::Layer` that buffers records in memory, and a screen
that renders them, filterable by level and by target.

Fields keep their types. A visitor collects each one as a typed JSON value rather
than folding everything into one formatted line: flattening on the way out is
exactly what makes a structured log stop being worth having, and a number that
arrives as a string cannot be filtered or compared. The screen renders them as
separate `key=value` pairs.

The buffer is capped at 2000 records and drains on read, like the event stream.
Tests cover field typing, target capture, the cap dropping oldest first, and a
second drain not replaying the first.

## Which ADR governs it

[ADR-0004](docs/adr/0004-ui-boundary.md): the layer lives in `apps/desktop`, and
the Core keeps emitting plain `tracing` calls knowing nothing about where they go.

Closes #15.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Commits signed off (`git commit -s`)
- [x] SPDX header on every new source file
- [x] No game-specific knowledge added under `crates/`, that belongs in a plugin
- [x] No `tauri::` outside `apps/desktop/`
