### PR TITLE
feat(desktop): add the Profiles screen and persist per-game Governor limits

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,18 +6,18 @@
 //! web view. No decision about a session is taken here.
 
 mod logs;
+mod profiles;
 mod session;
 mod updates;
 
 #[cfg(test)]
 mod tests;
 
-fn plugin_root(app: &tauri::AppHandle) -> std::path::PathBuf {
+fn data_dir(app: &tauri::AppHandle) -> std::path::PathBuf {
     use tauri::Manager;
     app.path()
         .app_data_dir()
-        .map(|dir| dir.join("plugins"))
-        .unwrap_or_else(|_| std::path::PathBuf::from("plugins"))
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
 }
 
 pub fn run() {
@@ -37,7 +37,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(move |app| {
             app.manage(updates::Updates::new(app.handle()));
-            app.manage(session::SessionHandle::new(plugin_root(app.handle())));
+            app.manage(session::SessionHandle::new(data_dir(app.handle())));
             app.manage(Arc::clone(&buffered));
             Ok(())
         })
@@ -50,6 +50,8 @@ pub fn run() {
             session::window_candidates,
             session::set_intent_enabled,
             logs::drain_logs,
+            session::profile,
+            session::set_profile,
             updates::update_settings,
             updates::set_update_channel,
             updates::check_for_update,

--- a/apps/desktop/src-tauri/src/profiles.rs
+++ b/apps/desktop/src-tauri/src/profiles.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Per-game Governor limits, kept on disk (#17).
+//!
+//! The limits themselves live in `idlewarden_core::GovernorConfig` and are
+//! enforced there. Nothing in this file decides whether an action is allowed;
+//! it stores what the user asked for and hands it to the Governor at the start
+//! of a session.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use idlewarden_core::GovernorConfig;
+use serde::{Deserialize, Serialize};
+
+/// What the Profiles screen edits for one plugin.
+///
+/// `disabled_intents` is a deny list rather than the Governor's allow list
+/// because the set of intents belongs to the plugin: a plugin that gains an
+/// intent should have it enabled by default, not silently excluded because an
+/// allow list written months earlier never heard of it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Profile {
+    pub max_actions_per_minute: u32,
+    pub min_confidence: f64,
+    pub max_observation_age_ms: u64,
+    pub max_session_minutes: u32,
+    pub disabled_intents: Vec<String>,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        let governor = GovernorConfig::default();
+        Profile {
+            max_actions_per_minute: governor.max_actions_per_minute,
+            min_confidence: governor.min_confidence,
+            max_observation_age_ms: governor.max_observation_age_ms,
+            max_session_minutes: governor.max_session_minutes,
+            disabled_intents: Vec::new(),
+        }
+    }
+}
+
+impl Profile {
+    /// Bounds every field to a range where the limit still means something.
+    ///
+    /// A confidence floor of 0 or a rate ceiling of 0 does not relax a limit,
+    /// it removes it, and a UI slip should not be able to do that quietly. The
+    /// Governor keeps making the decisions; this only refuses to store a
+    /// setting that would make them meaningless.
+    pub fn clamped(mut self) -> Self {
+        self.max_actions_per_minute = self.max_actions_per_minute.clamp(1, 600);
+        self.min_confidence = if self.min_confidence.is_finite() {
+            self.min_confidence.clamp(0.05, 1.0)
+        } else {
+            Profile::default().min_confidence
+        };
+        self.max_observation_age_ms = self.max_observation_age_ms.clamp(100, 60_000);
+        self.max_session_minutes = self.max_session_minutes.clamp(1, 1_440);
+        self.disabled_intents.sort();
+        self.disabled_intents.dedup();
+        self
+    }
+
+    /// The Governor's own configuration, with the deny list resolved against
+    /// the intents this plugin actually declares.
+    pub fn governor(&self, intents: &[String]) -> GovernorConfig {
+        let allowed: Vec<String> = intents
+            .iter()
+            .filter(|name| self.is_enabled(name))
+            .cloned()
+            .collect();
+
+        GovernorConfig {
+            max_actions_per_minute: self.max_actions_per_minute,
+            min_confidence: self.min_confidence,
+            max_observation_age_ms: self.max_observation_age_ms,
+            max_session_minutes: self.max_session_minutes,
+            allowed_intents: Some(allowed),
+        }
+    }
+
+    pub fn is_enabled(&self, intent: &str) -> bool {
+        !self.disabled_intents.iter().any(|name| name == intent)
+    }
+
+    pub fn set_enabled(&mut self, intent: &str, enabled: bool) {
+        if enabled {
+            self.disabled_intents.retain(|name| name != intent);
+        } else if self.is_enabled(intent) {
+            self.disabled_intents.push(intent.to_owned());
+            self.disabled_intents.sort();
+        }
+    }
+}
+
+/// Every plugin's profile, backed by one JSON file.
+#[derive(Debug)]
+pub struct Profiles {
+    path: PathBuf,
+    entries: BTreeMap<String, Profile>,
+}
+
+impl Profiles {
+    /// A missing or unreadable file is not an error worth stopping for: it
+    /// means "no profile has been saved yet", and defaults are a correct answer
+    /// to that.
+    pub fn load(path: &Path) -> Self {
+        let entries = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default();
+
+        Profiles {
+            path: path.to_owned(),
+            entries,
+        }
+    }
+
+    pub fn get(&self, plugin: &str) -> Profile {
+        self.entries.get(plugin).cloned().unwrap_or_default()
+    }
+
+    pub fn set(&mut self, plugin: &str, profile: Profile) -> Profile {
+        let stored = profile.clamped();
+        self.entries.insert(plugin.to_owned(), stored.clone());
+        self.save();
+        stored
+    }
+
+    pub fn update(&mut self, plugin: &str, change: impl FnOnce(&mut Profile)) -> Profile {
+        let mut profile = self.get(plugin);
+        change(&mut profile);
+        self.set(plugin, profile)
+    }
+
+    fn save(&self) {
+        if let Some(parent) = self.path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Ok(serialised) = serde_json::to_string_pretty(&self.entries) {
+            let _ = std::fs::write(&self.path, serialised);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp(name: &str) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("idlewarden-{name}-{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    #[test]
+    fn a_missing_file_reads_as_defaults_rather_than_failing() {
+        let profiles = Profiles::load(&temp("absent"));
+
+        assert_eq!(profiles.get("anything"), Profile::default());
+    }
+
+    #[test]
+    fn a_corrupt_file_reads_as_defaults_rather_than_failing() {
+        let path = temp("corrupt");
+        std::fs::write(&path, "{ this is not json").expect("the fixture could be written");
+
+        let profiles = Profiles::load(&path);
+
+        assert_eq!(profiles.get("anything"), Profile::default());
+    }
+
+    #[test]
+    fn a_saved_profile_survives_a_reload() {
+        let path = temp("roundtrip");
+        let mut profiles = Profiles::load(&path);
+
+        profiles.set(
+            "quest",
+            Profile {
+                max_actions_per_minute: 4,
+                min_confidence: 0.9,
+                disabled_intents: vec!["buy_upgrade".to_owned()],
+                ..Profile::default()
+            },
+        );
+
+        let reloaded = Profiles::load(&path);
+        let profile = reloaded.get("quest");
+        assert_eq!(profile.max_actions_per_minute, 4);
+        assert_eq!(profile.min_confidence, 0.9);
+        assert_eq!(profile.disabled_intents, vec!["buy_upgrade".to_owned()]);
+    }
+
+    #[test]
+    fn a_zero_rate_ceiling_is_refused_because_it_removes_the_limit() {
+        let profile = Profile {
+            max_actions_per_minute: 0,
+            min_confidence: 0.0,
+            max_observation_age_ms: 0,
+            max_session_minutes: 0,
+            ..Profile::default()
+        }
+        .clamped();
+
+        assert_eq!(profile.max_actions_per_minute, 1);
+        assert_eq!(profile.min_confidence, 0.05);
+        assert_eq!(profile.max_observation_age_ms, 100);
+        assert_eq!(profile.max_session_minutes, 1);
+    }
+
+    #[test]
+    fn an_absurd_rate_ceiling_is_capped() {
+        let profile = Profile {
+            max_actions_per_minute: 10_000,
+            min_confidence: 4.0,
+            max_observation_age_ms: 10_000_000,
+            max_session_minutes: 100_000,
+            ..Profile::default()
+        }
+        .clamped();
+
+        assert_eq!(profile.max_actions_per_minute, 600);
+        assert_eq!(profile.min_confidence, 1.0);
+        assert_eq!(profile.max_observation_age_ms, 60_000);
+        assert_eq!(profile.max_session_minutes, 1_440);
+    }
+
+    #[test]
+    fn a_confidence_floor_that_is_not_a_number_falls_back_to_the_default() {
+        let profile = Profile {
+            min_confidence: f64::NAN,
+            ..Profile::default()
+        }
+        .clamped();
+
+        assert_eq!(profile.min_confidence, Profile::default().min_confidence);
+    }
+
+    #[test]
+    fn the_deny_list_becomes_the_governors_allow_list() {
+        let mut profile = Profile::default();
+        profile.set_enabled("buy_upgrade", false);
+
+        let config = profile.governor(&[
+            "collect_reward".to_owned(),
+            "buy_upgrade".to_owned(),
+            "dismiss_popup".to_owned(),
+        ]);
+
+        assert_eq!(
+            config.allowed_intents,
+            Some(vec![
+                "collect_reward".to_owned(),
+                "dismiss_popup".to_owned()
+            ])
+        );
+    }
+
+    #[test]
+    fn a_plugin_that_gains_an_intent_has_it_enabled() {
+        let mut profile = Profile::default();
+        profile.set_enabled("buy_upgrade", false);
+
+        let config = profile.governor(&["buy_upgrade".to_owned(), "brand_new".to_owned()]);
+
+        assert_eq!(
+            config.allowed_intents,
+            Some(vec!["brand_new".to_owned()]),
+            "a deny list must not exclude intents it never heard of"
+        );
+    }
+
+    #[test]
+    fn disabling_every_intent_does_not_collapse_into_allowing_all() {
+        let mut profile = Profile::default();
+        profile.set_enabled("collect_reward", false);
+
+        let config = profile.governor(&["collect_reward".to_owned()]);
+
+        assert_eq!(
+            config.allowed_intents,
+            Some(Vec::new()),
+            "switching every intent off must reach the Governor as `none allowed`,              not as `no restriction`"
+        );
+    }
+
+    #[test]
+    fn disabling_the_same_intent_twice_does_not_duplicate_it() {
+        let mut profile = Profile::default();
+        profile.set_enabled("buy_upgrade", false);
+        profile.set_enabled("buy_upgrade", false);
+
+        assert_eq!(profile.disabled_intents, vec!["buy_upgrade".to_owned()]);
+    }
+
+    #[test]
+    fn re_enabling_an_intent_removes_it_from_the_deny_list() {
+        let mut profile = Profile::default();
+        profile.set_enabled("buy_upgrade", false);
+        profile.set_enabled("buy_upgrade", true);
+
+        assert!(profile.disabled_intents.is_empty());
+        assert!(profile.is_enabled("buy_upgrade"));
+    }
+}

--- a/apps/desktop/src-tauri/src/session.rs
+++ b/apps/desktop/src-tauri/src/session.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -10,14 +9,16 @@ use idlewarden_capture::CaptureBackend;
 use idlewarden_capture::WindowsCapture;
 use idlewarden_core::detector::{Candidate, DesktopWindows};
 use idlewarden_core::{
-    load_all, Command, Detector, Event, Governor, GovernorConfig, Parts, PluginBundle, Refusal,
-    Runner, Session, SessionService, SessionState, DEFAULT_TICK,
+    load_all, Command, Detector, Event, Governor, Parts, PluginBundle, Refusal, Runner, Session,
+    SessionService, SessionState, DEFAULT_TICK,
 };
 #[cfg(windows)]
 use idlewarden_input::{DryRunBackend, Humanisation, SendInputBackend};
 use idlewarden_input::{InputBackend, KillSwitch};
 use serde::Serialize;
 use tauri::State;
+
+use crate::profiles::{Profile, Profiles};
 
 type Backends = (Box<dyn CaptureBackend>, Box<dyn InputBackend>);
 
@@ -57,9 +58,9 @@ struct Inner {
     service: Option<SessionService>,
     events: Vec<Published>,
     kill: KillSwitch,
-    /// Intents the user switched off, keyed `plugin::intent`. The Governor is
-    /// told about them when a session starts.
-    disabled: HashSet<String>,
+    /// Per-game limits, on disk. The Governor is handed them when a session
+    /// starts; nothing here decides whether an action is allowed.
+    profiles: Profiles,
 }
 
 /// One plugin as the sidebar and the automations list need it.
@@ -101,7 +102,9 @@ pub struct IntentSummary {
 }
 
 impl SessionHandle {
-    pub fn new(plugin_root: PathBuf) -> Self {
+    pub fn new(data_dir: PathBuf) -> Self {
+        let plugin_root = data_dir.join("plugins");
+        let profiles = Profiles::load(&data_dir.join("profiles.json"));
         let mut plugins = Vec::new();
         let mut events = Vec::new();
 
@@ -138,7 +141,7 @@ impl SessionHandle {
             service: None,
             events,
             kill: KillSwitch::new(),
-            disabled: HashSet::new(),
+            profiles,
         }))
     }
 }
@@ -202,17 +205,12 @@ impl Inner {
         Err("capture and input are only implemented on Windows".to_owned())
     }
 
-    fn key(plugin: &str, intent: &str) -> String {
-        format!("{plugin}::{intent}")
-    }
-
-    fn allowed(&self, bundle: &PluginBundle) -> Vec<String> {
+    fn declared(bundle: &PluginBundle) -> Vec<String> {
         bundle
             .rules
             .intents
             .iter()
             .map(|intent| intent.name.clone())
-            .filter(|name| !self.disabled.contains(&Self::key(&bundle.id.0, name)))
             .collect()
     }
 
@@ -222,17 +220,18 @@ impl Inner {
             .map(|bundle| PluginSummary {
                 id: bundle.id.0.clone(),
                 detected: self.session.plugin.as_ref() == Some(&bundle.id),
-                intents: bundle
-                    .rules
-                    .intents
-                    .iter()
-                    .map(|intent| IntentSummary {
-                        name: intent.name.clone(),
-                        enabled: !self
-                            .disabled
-                            .contains(&Self::key(&bundle.id.0, &intent.name)),
-                    })
-                    .collect(),
+                intents: {
+                    let profile = self.profiles.get(&bundle.id.0);
+                    bundle
+                        .rules
+                        .intents
+                        .iter()
+                        .map(|intent| IntentSummary {
+                            name: intent.name.clone(),
+                            enabled: profile.is_enabled(&intent.name),
+                        })
+                        .collect()
+                },
             })
             .collect()
     }
@@ -251,7 +250,8 @@ impl Inner {
             return Err(Refusal::NoGameReady);
         };
 
-        let allowed = self.allowed(bundle);
+        let profile = self.profiles.get(&bundle.id.0);
+        let governor = profile.governor(&Self::declared(bundle));
 
         let (capture, input) = match self.backends(window) {
             Ok(backends) => backends,
@@ -270,13 +270,7 @@ impl Inner {
                 actuator: Box::new(bundle.actuator()),
                 input,
                 kill: self.kill.clone(),
-                governor: Governor::new(
-                    GovernorConfig {
-                        allowed_intents: allowed,
-                        ..GovernorConfig::default()
-                    },
-                    0,
-                ),
+                governor: Governor::new(governor, 0),
                 session: self.session.clone(),
             }),
             DEFAULT_TICK,
@@ -384,13 +378,25 @@ pub fn set_intent_enabled(
     enabled: bool,
 ) -> Vec<PluginSummary> {
     let mut inner = handle.0.lock().expect("session lock");
-    let key = Inner::key(&plugin, &intent);
-    if enabled {
-        inner.disabled.remove(&key);
-    } else {
-        inner.disabled.insert(key);
-    }
+    inner
+        .profiles
+        .update(&plugin, |profile| profile.set_enabled(&intent, enabled));
     inner.summaries()
+}
+
+/// The limits one plugin runs under. Defaults until the user saves something.
+#[tauri::command]
+pub fn profile(handle: State<'_, SessionHandle>, plugin: String) -> Profile {
+    let inner = handle.0.lock().expect("session lock");
+    inner.profiles.get(&plugin)
+}
+
+/// Stores the edited limits and returns what was actually kept, which is the
+/// clamped form rather than the raw input.
+#[tauri::command]
+pub fn set_profile(handle: State<'_, SessionHandle>, plugin: String, profile: Profile) -> Profile {
+    let mut inner = handle.0.lock().expect("session lock");
+    inner.profiles.set(&plugin, profile)
 }
 
 #[tauri::command]

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -21,6 +21,7 @@ export class AppComponent {
     { path: "/detection", label: "Détection" },
     { path: "/activite", label: "Activité" },
     { path: "/journaux", label: "Journaux" },
+    { path: "/profils", label: "Profils" },
   ];
 
   stateOf(plugin: PluginSummary): string {

--- a/apps/desktop/src/app/app.routes.ts
+++ b/apps/desktop/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { Routes } from "@angular/router";
 import { ActivityComponent } from "./activity/activity.component";
 import { DetectComponent } from "./detect/detect.component";
 import { LogsComponent } from "./logs/logs.component";
+import { ProfilesComponent } from "./profiles/profiles.component";
 import { SessionComponent } from "./session/session.component";
 
 export const routes: Routes = [
@@ -10,4 +11,5 @@ export const routes: Routes = [
   { path: "detection", component: DetectComponent },
   { path: "activite", component: ActivityComponent },
   { path: "journaux", component: LogsComponent },
+  { path: "profils", component: ProfilesComponent },
 ];

--- a/apps/desktop/src/app/profiles/profiles.component.css
+++ b/apps/desktop/src/app/profiles/profiles.component.css
@@ -1,0 +1,139 @@
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  padding: 26px 30px;
+  overflow-y: auto;
+}
+
+header .who h1 {
+  font-size: 17px;
+}
+
+header .status {
+  margin: 6px 0 0;
+  color: var(--muted);
+  max-width: 64ch;
+}
+
+.picker {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.picker button.on {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.limits {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(21em, 1fr));
+  gap: 18px;
+}
+
+.limits article {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 14px 16px;
+  border: 1px solid var(--rule);
+  background: var(--panel);
+}
+
+.limits label {
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+input[type="range"] {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.reading {
+  color: var(--bright);
+  min-width: 9em;
+  text-align: right;
+}
+
+.hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.intents {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.automation {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 12px;
+  border: 1px solid var(--rule);
+  background: var(--panel);
+}
+
+.automation .title {
+  color: var(--bright);
+}
+
+.toggle {
+  width: 42px;
+  height: 22px;
+  padding: 0;
+  border-radius: 999px;
+  border: 2px solid var(--line);
+  position: relative;
+}
+
+.toggle[aria-checked="true"] {
+  border-color: var(--accent);
+}
+
+.toggle .knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--muted);
+  transition: left 120ms ease;
+}
+
+.toggle[aria-checked="true"] .knob {
+  left: 22px;
+  background: var(--accent);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.note {
+  color: var(--accent);
+  font-size: 11px;
+}
+
+.muted {
+  margin: 0;
+  color: var(--muted);
+}

--- a/apps/desktop/src/app/profiles/profiles.component.html
+++ b/apps/desktop/src/app/profiles/profiles.component.html
@@ -1,0 +1,86 @@
+<main>
+  <header>
+    <div class="who">
+      <h1>Profils</h1>
+      <p class="status">
+        Les limites que le Gouverneur applique, par jeu. Cet écran les modifie, il ne
+        rejoue aucune des vérifications.
+      </p>
+    </div>
+  </header>
+
+  @if (plugins().length === 0) {
+    <p class="muted">Aucun plugin installé, donc rien à régler.</p>
+  } @else {
+    <div class="picker">
+      @for (entry of plugins(); track entry.id) {
+        <button
+          type="button"
+          [class.on]="plugin() === entry.id"
+          (click)="choose(entry.id)"
+        >
+          {{ entry.id }}
+        </button>
+      }
+    </div>
+
+    @if (profile(); as current) {
+      <section class="limits">
+        @for (limit of limits; track limit.key) {
+          <article>
+            <label [attr.for]="limit.key">{{ limit.label }}</label>
+            <div class="row">
+              <input
+                type="range"
+                [id]="limit.key"
+                [min]="limit.min"
+                [max]="limit.max"
+                [step]="limit.step"
+                [value]="value(limit)"
+                (input)="edit(limit.key, $any($event.target).value)"
+              />
+              <span class="reading">{{ value(limit) }} {{ limit.unit }}</span>
+            </div>
+            <p class="hint">{{ limit.hint }}</p>
+          </article>
+        }
+      </section>
+
+      <section class="intents">
+        <p class="label">Automatisations autorisées</p>
+        @for (intent of intents(); track intent.name) {
+          <div class="automation">
+            <span class="title">{{ intent.name }}</span>
+            <button
+              type="button"
+              class="toggle"
+              role="switch"
+              [attr.aria-checked]="intent.enabled"
+              [attr.aria-label]="intent.name"
+              (click)="toggleIntent(intent.name, !intent.enabled)"
+            >
+              <span class="knob"></span>
+            </button>
+          </div>
+        } @empty {
+          <p class="muted">Ce plugin ne déclare aucune automatisation.</p>
+        }
+        <p class="hint">
+          Les bascules sont enregistrées tout de suite. Une veille déjà lancée n'est pas
+          interrompue.
+        </p>
+      </section>
+
+      <div class="actions">
+        <button type="button" (click)="save()">Enregistrer les limites</button>
+        @if (saved()) {
+          <span class="note">
+            Enregistré. Les valeurs affichées sont celles réellement retenues.
+          </span>
+        }
+      </div>
+    } @else {
+      <p class="muted">Lecture du profil…</p>
+    }
+  }
+</main>

--- a/apps/desktop/src/app/profiles/profiles.component.ts
+++ b/apps/desktop/src/app/profiles/profiles.component.ts
@@ -1,0 +1,141 @@
+import { Component, computed, effect, inject, signal } from "@angular/core";
+
+import { Profile } from "../session/session.model";
+import { SessionService } from "../session/session.service";
+
+interface Limit {
+  key:
+    | "max_actions_per_minute"
+    | "min_confidence"
+    | "max_observation_age_ms"
+    | "max_session_minutes";
+  label: string;
+  hint: string;
+  min: number;
+  max: number;
+  step: number;
+  unit: string;
+}
+
+const LIMITS: readonly Limit[] = [
+  {
+    key: "max_actions_per_minute",
+    label: "Plafond d'actions",
+    hint: "Un jeu idle n'a pas besoin de plus de quelques actions par minute.",
+    min: 1,
+    max: 600,
+    step: 1,
+    unit: "par minute",
+  },
+  {
+    key: "min_confidence",
+    label: "Seuil de confiance",
+    hint: "En dessous, le Gardien s'arrête plutôt que de deviner.",
+    min: 0.05,
+    max: 1,
+    step: 0.05,
+    unit: "",
+  },
+  {
+    key: "max_observation_age_ms",
+    label: "Âge maximal d'une observation",
+    hint: "Une image plus vieille que ça n'est plus une base pour agir.",
+    min: 100,
+    max: 60000,
+    step: 100,
+    unit: "ms",
+  },
+  {
+    key: "max_session_minutes",
+    label: "Budget de session",
+    hint: "Au-delà, la veille s'arrête d'elle-même.",
+    min: 1,
+    max: 1440,
+    step: 10,
+    unit: "minutes",
+  },
+];
+
+@Component({
+  selector: "app-profiles",
+  templateUrl: "./profiles.component.html",
+  styleUrl: "./profiles.component.css",
+})
+export class ProfilesComponent {
+  private readonly sessions = inject(SessionService);
+
+  readonly limits = LIMITS;
+  readonly plugins = this.sessions.plugins;
+  readonly chosen = signal<string | null>(null);
+  readonly saved = signal(false);
+
+  readonly plugin = computed(() => {
+    const chosen = this.chosen();
+    const known = this.plugins();
+    if (chosen !== null && known.some((entry) => entry.id === chosen)) {
+      return chosen;
+    }
+    return known.find((entry) => entry.detected)?.id ?? known[0]?.id ?? null;
+  });
+
+  readonly intents = computed(
+    () => this.plugins().find((entry) => entry.id === this.plugin())?.intents ?? [],
+  );
+
+  readonly profile = signal<Profile | null>(null);
+
+  /// The limits follow whichever plugin is selected, including the first time
+  /// detection names one.
+  constructor() {
+    effect(() => {
+      const plugin = this.plugin();
+      if (plugin === null) {
+        this.profile.set(null);
+        return;
+      }
+      void this.sessions.profile(plugin).then((loaded) => this.profile.set(loaded));
+    });
+  }
+
+  choose(plugin: string): void {
+    this.chosen.set(plugin);
+    this.saved.set(false);
+  }
+
+  edit(key: Limit["key"], raw: string): void {
+    const current = this.profile();
+    if (current === null) {
+      return;
+    }
+    const value = Number(raw);
+    if (!Number.isFinite(value)) {
+      return;
+    }
+    this.profile.set({ ...current, [key]: value });
+    this.saved.set(false);
+  }
+
+  value(limit: Limit): number {
+    return this.profile()?.[limit.key] ?? 0;
+  }
+
+  /// The Rust side clamps what it stores, so the answer it returns is the
+  /// truth, not the numbers that were typed.
+  async save(): Promise<void> {
+    const plugin = this.plugin();
+    const edited = this.profile();
+    if (plugin === null || edited === null) {
+      return;
+    }
+    this.profile.set(await this.sessions.saveProfile(plugin, edited));
+    this.saved.set(true);
+  }
+
+  toggleIntent(intent: string, enabled: boolean): void {
+    const plugin = this.plugin();
+    if (plugin === null) {
+      return;
+    }
+    void this.sessions.setIntentEnabled(plugin, intent, enabled);
+  }
+}

--- a/apps/desktop/src/app/session/session.model.ts
+++ b/apps/desktop/src/app/session/session.model.ts
@@ -86,6 +86,16 @@ export interface IntentSummary {
   enabled: boolean;
 }
 
+/// The Governor limits one plugin runs under. `disabled_intents` is a deny
+/// list: an intent the plugin gains later is enabled by default.
+export interface Profile {
+  max_actions_per_minute: number;
+  min_confidence: number;
+  max_observation_age_ms: number;
+  max_session_minutes: number;
+  disabled_intents: string[];
+}
+
 export type LogLevel = "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE";
 
 /// One `tracing` event. `fields` keeps the structured values the Core emitted

--- a/apps/desktop/src/app/session/session.service.ts
+++ b/apps/desktop/src/app/session/session.service.ts
@@ -6,6 +6,7 @@ import {
   LogRecord,
   Observation,
   PluginSummary,
+  Profile,
   PublishedEvent,
   Refused,
   Session,
@@ -90,6 +91,16 @@ export class SessionService {
 
   async refreshPlugins(): Promise<void> {
     this.known.set(await invoke<PluginSummary[]>("plugins"));
+  }
+
+  async profile(plugin: string): Promise<Profile> {
+    return await invoke<Profile>("profile", { plugin });
+  }
+
+  /// Returns what was stored, not what was sent: the Rust side clamps limits
+  /// that would remove a check rather than loosen it.
+  async saveProfile(plugin: string, profile: Profile): Promise<Profile> {
+    return await invoke<Profile>("set_profile", { plugin, profile });
   }
 
   async setIntentEnabled(

--- a/crates/core/src/governor.rs
+++ b/crates/core/src/governor.rs
@@ -30,8 +30,12 @@ pub struct GovernorConfig {
     pub max_observation_age_ms: u64,
     /// Wall-clock ceiling for one session.
     pub max_session_minutes: u32,
-    /// Intents the active profile is allowed to emit. Empty means "all".
-    pub allowed_intents: Vec<String>,
+    /// Intents the active profile may emit. `None` means the profile does not
+    /// restrict them; `Some(list)` means exactly those, and an empty list means
+    /// none. It is an `Option` rather than a bare `Vec` because "the user
+    /// switched every intent off" and "the user set no restriction" are
+    /// opposite instructions, and an empty vector cannot tell them apart.
+    pub allowed_intents: Option<Vec<String>>,
 }
 
 impl Default for GovernorConfig {
@@ -41,7 +45,7 @@ impl Default for GovernorConfig {
             min_confidence: 0.75,
             max_observation_age_ms: 2_000,
             max_session_minutes: 480,
-            allowed_intents: Vec::new(),
+            allowed_intents: None,
         }
     }
 }
@@ -94,12 +98,12 @@ impl Governor {
             };
         }
 
-        if !self.config.allowed_intents.is_empty()
-            && !self.config.allowed_intents.contains(&intent.name)
-        {
-            return Verdict::Reject {
-                reason: format!("intent `{}` is not allowed by this profile", intent.name),
-            };
+        if let Some(allowed) = &self.config.allowed_intents {
+            if !allowed.contains(&intent.name) {
+                return Verdict::Reject {
+                    reason: format!("intent `{}` is not allowed by this profile", intent.name),
+                };
+            }
         }
 
         self.recent.retain(|t| now_ms.saturating_sub(*t) < 60_000);
@@ -180,9 +184,25 @@ mod tests {
     }
 
     #[test]
+    fn an_empty_allow_list_rejects_every_intent() {
+        let cfg = GovernorConfig {
+            allowed_intents: Some(Vec::new()),
+            ..GovernorConfig::default()
+        };
+        let mut governor = Governor::new(cfg, 0);
+
+        let verdict = governor.review(&Intent::new("collect_reward"), &obs(1.0, 0), 0);
+
+        assert!(
+            matches!(verdict, Verdict::Reject { .. }),
+            "a profile with nothing allowed must not be read as allowing everything"
+        );
+    }
+
+    #[test]
     fn rejects_intents_outside_the_profile() {
         let cfg = GovernorConfig {
-            allowed_intents: vec!["buy_upgrade".into()],
+            allowed_intents: Some(vec!["buy_upgrade".into()]),
             ..Default::default()
         };
         let mut g = Governor::new(cfg, 0);

--- a/crates/core/src/runner/tests.rs
+++ b/crates/core/src/runner/tests.rs
@@ -261,7 +261,7 @@ fn a_session_that_cannot_act_still_observes() {
 #[test]
 fn a_rejected_intent_is_published_with_its_reason_and_costs_no_action() {
     let mut build = Build::new();
-    build.config.allowed_intents = vec!["something_else".to_owned()];
+    build.config.allowed_intents = Some(vec!["something_else".to_owned()]);
     let (mut runner, _kill) = build.build();
 
     runner.tick(1000);


### PR DESCRIPTION
## What this changes

Per-game Governor limits, edited on screen and kept on disk: rate ceiling,
confidence floor, observation age, session budget, allowed intents. Nothing here
decides whether an action is allowed; the limits are handed to the Governor when a
session starts and it keeps making every decision.

This replaces the in-memory `HashSet` of disabled intents, which was a second
source of truth and did not survive a restart.

**One Core change, and it fixes a real footgun.** `GovernorConfig.allowed_intents`
was a `Vec` where empty meant "all". Switching every intent off in the UI produced
an empty list, which the Governor would have read as permission for everything:
the exact opposite of what the user asked for. It is `Option<Vec<String>>` now,
where `None` is "no restriction" and `Some(vec![])` is "none allowed". A Governor
test pins that.

Limits are clamped on the way in. A confidence floor of 0 or a rate ceiling of 0
does not loosen a limit, it removes it, and a slider slip should not be able to do
that quietly. The command returns what was actually stored rather than what was
sent, so the screen shows the truth.

The deny list stores disabled intents rather than allowed ones, so a plugin that
gains an intent later has it enabled rather than silently excluded by a list
written before it existed. Tested.

## Which ADR governs it

[ADR-0009](docs/adr/0009-governor.md): the Governor stays the single choke point.
This only stores and forwards its configuration.

Closes #17.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Commits signed off (`git commit -s`)
- [x] SPDX header on every new source file
- [x] No game-specific knowledge added under `crates/`, that belongs in a plugin
- [x] No `tauri::` outside `apps/desktop/`
