### PR TITLE
fix: expose capture and input primitives so the Linux check builds

### DIFF
--- a/crates/capture/src/frame.rs
+++ b/crates/capture/src/frame.rs
@@ -36,7 +36,18 @@ impl std::fmt::Debug for Frame {
     }
 }
 
-pub(crate) fn pack_rows(src: &[u8], row_pitch: usize, size: Size) -> Option<Vec<u8>> {
+/// Copies a padded capture buffer into tight rows.
+///
+/// A GPU hands back rows padded to its own alignment, so `row_pitch` is almost
+/// never `size.row_bytes()`. Every capture backend has to undo that, which is
+/// why this is part of the crate's surface rather than one backend's private
+/// helper: it is the same arithmetic on Windows and on the X11/Wayland backends
+/// #11 will add, and it is worth testing once on every platform rather than
+/// only where a backend happens to exist today.
+///
+/// Returns `None` when `src` is too small for the described image, rather than
+/// reading past it.
+pub fn pack_rows(src: &[u8], row_pitch: usize, size: Size) -> Option<Vec<u8>> {
     let row = size.row_bytes();
     if row_pitch < row {
         return None;

--- a/crates/capture/src/lib.rs
+++ b/crates/capture/src/lib.rs
@@ -24,7 +24,7 @@ mod steam;
 mod wgc;
 
 pub use detect::{detect, matches, Detection, GameWindow};
-pub use frame::{Frame, Size};
+pub use frame::{pack_rows, Frame, Size};
 pub use null::NullBackend;
 
 #[cfg(windows)]

--- a/crates/capture/src/wgc.rs
+++ b/crates/capture/src/wgc.rs
@@ -26,7 +26,7 @@ use windows::Win32::System::WinRT::Direct3D11::{
 use windows::Win32::System::WinRT::Graphics::Capture::IGraphicsCaptureItemInterop;
 use windows::Win32::UI::WindowsAndMessaging::IsWindow;
 
-use crate::frame::pack_rows;
+use crate::pack_rows;
 use crate::{CaptureBackend, CaptureError, Frame, Size, WindowHandle};
 
 const BUFFERS: i32 = 2;

--- a/crates/input/src/coords.rs
+++ b/crates/input/src/coords.rs
@@ -4,7 +4,7 @@ use idlewarden_plugin_api::Point;
 /// A rectangle in screen pixels. Origin can be negative: a monitor placed left
 /// of the primary one starts at a negative x.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct Rect {
+pub struct Rect {
     pub left: i32,
     pub top: i32,
     pub width: i32,
@@ -13,7 +13,7 @@ pub(crate) struct Rect {
 
 /// Window-relative `0.0..=1.0` to screen pixels, converted as late as possible
 /// so that moving or resizing the window costs nothing upstream (ADR-0007).
-pub(crate) fn to_screen(point: Point, client: Rect) -> Option<(i32, i32)> {
+pub fn to_screen(point: Point, client: Rect) -> Option<(i32, i32)> {
     if client.width <= 0 || client.height <= 0 {
         return None;
     }
@@ -28,7 +28,7 @@ pub(crate) fn to_screen(point: Point, client: Rect) -> Option<(i32, i32)> {
 /// Screen pixels to the `0..=65535` space `SendInput` expects for absolute
 /// motion, normalised over the whole virtual desktop rather than the primary
 /// monitor.
-pub(crate) fn to_absolute(x: i32, y: i32, desktop: Rect) -> Option<(i32, i32)> {
+pub fn to_absolute(x: i32, y: i32, desktop: Rect) -> Option<(i32, i32)> {
     if desktop.width <= 1 || desktop.height <= 1 {
         return None;
     }

--- a/crates/input/src/humanise.rs
+++ b/crates/input/src/humanise.rs
@@ -5,12 +5,12 @@ use crate::Humanisation;
 ///
 /// Seeded and deterministic on purpose: the point is that consecutive delays
 /// differ, and that property is only testable if the sequence can be replayed.
-pub(crate) struct Jitter {
+pub struct Jitter {
     state: u64,
 }
 
 impl Jitter {
-    pub(crate) fn new(seed: u64) -> Self {
+    pub fn new(seed: u64) -> Self {
         Jitter {
             state: if seed == 0 { 0x9E3779B97F4A7C15 } else { seed },
         }
@@ -25,7 +25,7 @@ impl Jitter {
         x
     }
 
-    pub(crate) fn delay_ms(&mut self, humanisation: Humanisation) -> u64 {
+    pub fn delay_ms(&mut self, humanisation: Humanisation) -> u64 {
         let (low, high) = if humanisation.min_delay_ms <= humanisation.max_delay_ms {
             (humanisation.min_delay_ms, humanisation.max_delay_ms)
         } else {

--- a/crates/input/src/keys.rs
+++ b/crates/input/src/keys.rs
@@ -4,7 +4,7 @@
 ///
 /// Unknown names return `None` rather than a default, because pressing the
 /// wrong key in a game is worse than pressing none.
-pub(crate) fn virtual_key(name: &str) -> Option<u16> {
+pub fn virtual_key(name: &str) -> Option<u16> {
     let name = name.trim().to_ascii_lowercase();
 
     if name.len() == 1 {

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -12,6 +12,10 @@ mod coords;
 mod humanise;
 mod keys;
 
+pub use coords::{to_absolute, to_screen, Rect};
+pub use humanise::Jitter;
+pub use keys::virtual_key;
+
 #[cfg(windows)]
 mod sendinput;
 


### PR DESCRIPTION
## What this changes

`check (ubuntu-latest)` has been failing on `main` for several runs, so nothing
could go green. Six items across `crates/capture` and `crates/input` are
`pub(crate)` and their only non-test callers are `wgc.rs` and `sendinput.rs`,
both `#[cfg(windows)]`. On Linux the lib targets have no caller at all, and
`RUSTFLAGS: -D warnings` turns `dead_code` into a build failure:

- `capture`: `pack_rows`
- `input`: `Rect`, `to_screen`, `to_absolute`, `Jitter`, `virtual_key`

They are now part of their crates' surfaces rather than one backend's private
helpers. That is not a way of silencing the lint, it is what these functions are.
Undoing a GPU's row padding, converting window-relative coordinates to screen
pixels, mapping a key name to a virtual-key code, jittering a delay: none of that
is Windows-specific, all of it is already tested on every platform, and the
X11/Wayland backends #11 will add need exactly the same pieces. Marking them
public says so, and keeps the tests running everywhere instead of gating them
behind the one platform that happens to have a backend today.

Making them public also means `dead_code` cannot fire again on a platform that
has no backend yet, which is the failure mode this is fixing.

No behaviour change. The Windows backends call them through the re-exports
instead of the private paths.

This sits at the bottom of the stack because every PR above it is blocked by the
same failure.

## Which ADR governs it

[ADR-0005](docs/adr/0005-capture.md) and [ADR-0007](docs/adr/0007-input.md),
both unchanged. This only moves helpers from crate-private to public.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Commits signed off (`git commit -s`)
- [x] SPDX header on every new source file
- [x] No game-specific knowledge added under `crates/`, that belongs in a plugin
- [x] No `tauri::` outside `apps/desktop/`
